### PR TITLE
asterisk: add asterisk18-addons-mysql

### DIFF
--- a/asterisk/Containerfile
+++ b/asterisk/Containerfile
@@ -10,6 +10,7 @@ RUN groupadd -g 991 -r asterisk \
         asterisk18-odbc \
         asterisk18-voicemail \
         asterisk18-debuginfo \
+        asterisk18-addons-mysql \
         asterisk18-voicemail-odbcstorage \
         unixODBC \
         mysql-connector-odbc \


### PR DESCRIPTION
Fix for odbc errors.

Before the patch:
```
Apr 04 15:51:47 dn1 nethvoice8[91512]: [Apr  4 15:51:47] WARNING[1]: res_odbc.c:571 load_odbc_config: Unable to load config file res_odbc.conf
Apr 04 15:51:48 dn1 nethvoice8[91512]: [Apr  4 15:51:48] ERROR[1]: loader.c:2508 load_modules: res_odbc declined to load.
Apr 04 15:51:48 dn1 nethvoice8[91512]: [Apr  4 15:51:48] ERROR[1]: loader.c:2508 load_modules: Declined modules which depend on res_odbc: res_config_odbc, cel_odbc, cdr_adaptive_odbc, cdr_odbc, func_odbc
```

After the patch:
```
Apr 04 15:54:53 dn1 nethvoice8[93456]: [2023-04-04 15:54:53] NOTICE[1]: res_odbc.c:697 load_odbc_config: Registered ODBC class 'asteriskcdrdb' dsn->[MySQL-asteriskcdrdb]
```