### PR TITLE
NS8 Backup and Restore

### DIFF
--- a/asterisk/Containerfile
+++ b/asterisk/Containerfile
@@ -42,6 +42,8 @@ RUN mkdir download \
 COPY --chown=asterisk:asterisk etc/asterisk /etc/asterisk
 COPY etc/odbc.ini /etc/odbc.ini
 COPY var/lib/asterisk /var/lib/asterisk
+COPY usr/bin/backup_astdb /usr/bin/backup_astdb
+COPY usr/bin/restore_astdb /usr/bin/restore_astdb
 RUN chown asterisk:asterisk /var/lib/asterisk/db
 COPY entrypoint.sh /entrypoint
 ENTRYPOINT [ "/entrypoint" ]

--- a/asterisk/entrypoint.sh
+++ b/asterisk/entrypoint.sh
@@ -5,10 +5,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-# initialize manager.conf with credentials from environment
-if [[ ! -f /etc/asterisk/manager.conf ]]; then
-        # Configure asterisk manager
-        cat > /etc/asterisk/manager.conf <<EOF
+# Configure asterisk manager
+cat > /etc/asterisk/manager.conf <<EOF
 [general]
 enabled = yes
 port = ${ASTMANAGERPORT:-5038}
@@ -27,7 +25,6 @@ writetimeout = 5000
 #include manager_custom.conf
 EOF
 chown asterisk:asterisk /etc/asterisk/manager.conf
-fi
 
 # Configure ODBC for asteriskcdrdb
 cat > /etc/odbc.ini <<EOF

--- a/asterisk/usr/bin/backup_astdb
+++ b/asterisk/usr/bin/backup_astdb
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+sqlite3 /var/lib/asterisk/db/astdb.sqlite3 .dump | grep -v "VALUES('\\/SIP\\|VALUES('\\/RG\\|VALUES('\\/BLKVM\\|VALUES('\\/FM\\|VALUES('\\/dundi\\|VALUES('\\/\\/\\|VALUES('\\/IAX])\\|VALUES('\\/CALLTRACE\\|ccss\\/last_number" > /var/lib/asterisk/db/astdb.sqlite3.dump

--- a/asterisk/usr/bin/restore_astdb
+++ b/asterisk/usr/bin/restore_astdb
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+sqlite3 /var/lib/asterisk/db/astdb.sqlite3 < /var/lib/asterisk/db/astdb.sqlite3.dump

--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -13,7 +13,7 @@ import agent
 import agent.tasks
 
 data = json.load(sys.stdin)
-lets_encrypt = data.get("lets_encrypt", False)
+lets_encrypt = data.get("lets_encrypt", 'false')
 
 agent.set_env('TRAEFIK_LETS_ENCRYPT', lets_encrypt)
 
@@ -29,8 +29,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-wizard',
         'url':  'http://127.0.0.1:' + os.environ["APACHE_PORT"] + '/' + os.environ["BRAND_NAME"].lower(),
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/' + os.environ["BRAND_NAME"].lower(),
     },
@@ -46,8 +46,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-freepbx',
         'url':  'http://127.0.0.1:' + os.environ["APACHE_PORT"] + '/freepbx',
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/freepbx',
     },
@@ -63,8 +63,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-tancredi',
         'url':  'http://127.0.0.1:' + os.environ["TANCREDIPORT"] + '/tancredi',
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/tancredi',
     },
@@ -80,8 +80,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-provisioning',
         'url':  'http://127.0.0.1:' + os.environ["TANCREDIPORT"] + '/provisioning',
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/provisioning',
     },
@@ -96,8 +96,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-ui',
         'url':  'http://127.0.0.1:' + os.environ["NETHCTI_UI_PORT"],
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHCTI_UI_HOST"],
     },
 )
@@ -112,8 +112,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-server-api',
         'url':  'http://127.0.0.1:' + os.environ["NETHCTI_SERVER_API_PORT"],
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/webrest',
         'strip_prefix': True,
@@ -135,8 +135,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-server-websocket',
         'url':  'http://127.0.0.1:' + os.environ["NETHCTI_SERVER_WS_PORT"] + '/socket.io',
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': lets_encrypt,
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': lets_encrypt == 'true',
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/socket.io',
         'headers': {
@@ -157,7 +157,7 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-janus',
         'url':  'http://127.0.0.1:' + os.environ["JANUS_TRANSPORT_PORT"],
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
         'lets_encrypt': lets_encrypt,
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/janus',

--- a/imageroot/actions/configure-module/71reports_api
+++ b/imageroot/actions/configure-module/71reports_api
@@ -30,8 +30,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-reports-api',
         'url': 'http://127.0.0.1:' + os.environ["REPORTS_API_PORT"],
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "True",
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "true",
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/pbx-report-api',
         'strip_prefix': True

--- a/imageroot/actions/configure-module/72reports_ui
+++ b/imageroot/actions/configure-module/72reports_ui
@@ -37,8 +37,8 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-reports-ui',
         'url': 'http://127.0.0.1:' + os.environ["REPORTS_UI_PORT"],
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "True",
-        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "True",
+        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "true",
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/pbx-report'
     },

--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -7,6 +7,7 @@
 
 # If the control reaches this step, the service can be enabled and started
 
+systemctl --user enable --now mariadb.service
 systemctl --user enable --now asterisk.service
 systemctl --user enable --now freepbx.service
 systemctl --user enable --now janus.service

--- a/imageroot/actions/create-module/05setenvs
+++ b/imageroot/actions/create-module/05setenvs
@@ -127,7 +127,7 @@ agent.set_env('STUNPORT', 19302)
 agent.set_env('ICEIGNORE', 'vmnet,tap,tun,virb,vb-')
 agent.set_env('LOCAL_IP', '172.25.5.83')
 
-agent.set_env('TRAEFIK_HTTP2HTTPS', 'True')
+agent.set_env('TRAEFIK_HTTP2HTTPS', 'true')
 
 agent.set_env('PHONEBOOK_DB_HOST', '127.0.0.1')
 agent.set_env('PHONEBOOK_DB_PORT', port_list[0])

--- a/imageroot/actions/create-module/80process_notifier
+++ b/imageroot/actions/create-module/80process_notifier
@@ -5,10 +5,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-# If the control reaches this step, the service can be enabled and started
-
-systemctl --user enable --now mariadb.service
-
 # prepare dir for watcher.path
 mkdir notify
 chmod a+rwx notify

--- a/imageroot/actions/restore-module/20copyenv
+++ b/imageroot/actions/restore-module/20copyenv
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+
+import agent
+
+# get old environment from action
+request = json.load(sys.stdin)
+old_envs = request['environment']
+
+# list of variables to restore
+restore_envs = [
+    'MARIADB_ROOT_PASSWORD',
+    'AMPDBUSER',
+    'AMPDBHOST',
+    'AMPDBNAME',
+    'AMPDBENGINE',
+    'AMPDBPASS',
+    'AMPMGRUSER',
+    'AMPMGRPASS',
+    'APACHE_RUN_USER',
+    'APACHE_RUN_GROUP',
+    'AMPASTERISKWEBGROUP',
+    'AMPASTERISKWEBUSER',
+    'NETHCTI_AMI_PASSWORD',
+    'BRAND_NAME',
+    'BRAND_SITE',
+    'BRAND_DOCS',
+    'CDRDBHOST',
+    'CDRDBNAME',
+    'CDRDBUSER',
+    'CDRDBPASS',
+    'NETHCTI_DB_HOST',
+    'NETHCTI_DB_USER',
+    'NETHCTI_DB_PASSWORD',
+    'TANCREDI_STATIC_TOKEN',
+    'NETHVOICESECRETKEY',
+    'JANUS_ADMIN_SECRET',
+    'JANUS_DEBUG_LEVEL',
+    'STUNSERVER',
+    'STUNPORT',
+    'ICEIGNORE',
+    'LOCAL_IP',
+    'TRAEFIK_HTTP2HTTPS',
+    'PHONEBOOK_DB_HOST',
+    'PHONEBOOK_DB_NAME',
+    'PHONEBOOK_DB_USER',
+    'PHONEBOOK_DB_PASS',
+    'PHONEBOOK_DB_USER',
+    'PHONEBOOK_LDAP_USER',
+    'PHONEBOOK_LDAP_PASS',
+    'PHONEBOOK_LDAP_LIMIT',
+    'REPORTS_PASSWORD',
+    'REPORTS_API_KEY',
+    'REPORTS_SECRET',
+    'NETHVOICE_HOST_LOCAL_NETWORKS',
+    'SUBSCRIPTION_SYSTEMID',
+    'SUBSCRIPTION_SECRET',
+    'NETHCTI_PREFIX',
+    'NETHCTI_AUTOC2C',
+    'NETHCTI_TRUNKS_EVENTS',
+    'NETHCTI_ALERTS',
+    'NETHCTI_AUTHENTICATION_ENABLED',
+    'NETHCTI_UNAUTHE_CALL',
+    'NETHCTI_UNAUTHE_CALL_IP',
+    'NETHCTI_JABBER_URL',
+    'NETHCTI_JABBER_DOMAIN',
+    'NETHCTI_CDR_SCRIPT',
+    'NETHCTI_CDR_SCRIPT_TIMEOUT',
+    'NETHCTI_CDR_SCRIPT_CALL_IN',
+    'NETHCTI_LOG_LEVEL',
+    'CONFERENCE_JITSI_URL',
+    'BRAND_APPID',
+    'FLEXISIP_LOG_LEVEL',
+    'NETHCTI_UI_PRODUCT_NAME',
+    'NETHCTI_UI_COMPANY_NAME',
+    'NETHCTI_UI_COMPANY_URL',
+    'USER_DOMAIN',
+    'REPORTS_UI_APP_NAME',
+    'REPORTS_UI_HELP_URL',
+    'REPORTS_UI_COMPANY_NAME',
+]
+
+for env in restore_envs:
+    agent.set_env(env, old_envs[env])

--- a/imageroot/actions/restore-module/21database
+++ b/imageroot/actions/restore-module/21database
@@ -1,0 +1,28 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+# prepare restore
+podman run \
+    --rm \
+    --name=prepare_db \
+    --volume=./db_backup:/backup:z \
+    "${NETHVOICE_MARIADB_IMAGE}" \
+    mariabackup --prepare --target-dir=/backup
+
+# execute restore in mariadb-data volume
+podman run \
+    --rm \
+    --name=restore_backup \
+    --volume=./db_backup:/backup:z \
+    --volume=mariadb-data:/var/lib/mysql:z \
+    "${NETHVOICE_MARIADB_IMAGE}" \
+    mariabackup --copy-back --target-dir=/backup
+
+# remove backup folder
+rm -rf db_backup

--- a/imageroot/actions/restore-module/22asterisk
+++ b/imageroot/actions/restore-module/22asterisk
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+# run asterisk instance so volumes are populated with initial data
+podman run \
+    --rm \
+    --detach \
+    --name asterisk_restore \
+    --volume=sounds:/var/lib/asterisk/sounds:Z \
+    --volume=astdb:/var/lib/asterisk/db:z \
+    "$NETHVOICE_ASTERISK_IMAGE" sleep infinity
+
+trap 'podman stop -t 0 asterisk_restore' EXIT
+
+# restore sqldump
+podman cp asterisk_backup/var/lib/asterisk/db/astdb.sqlite3.dump asterisk_restore:/var/lib/asterisk/db/astdb.sqlite3.dump
+podman exec asterisk_restore restore_astdb
+podman exec asterisk_restore chown asterisk:asterisk /var/lib/asterisk/db/astdb.sqlite3
+podman exec asterisk_restore rm /var/lib/asterisk/db/astdb.sqlite3.dump
+
+# restore all other files
+podman cp asterisk_backup/. asterisk_restore:/
+podman exec asterisk_restore chown -R asterisk:asterisk /var/lib/asterisk/sounds
+rm -rf asterisk_backup

--- a/imageroot/actions/restore-module/70configure_module
+++ b/imageroot/actions/restore-module/70configure_module
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+
+import agent
+
+# get old environment from action
+request = json.load(sys.stdin)
+old_envs = request['environment']
+
+# call configure module
+response = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='configure-module', data={
+    "nethvoice_host": old_envs["NETHVOICE_HOST"],
+    "nethcti_ui_host": old_envs["NETHCTI_UI_HOST"],
+    "lets_encrypt": old_envs["TRAEFIK_LETS_ENCRYPT"] == 'true',
+    "reports_international_prefix": old_envs["REPORTS_INTERNATIONAL_PREFIX"],
+})
+
+agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/restore-module/71reload_services
+++ b/imageroot/actions/restore-module/71reload_services
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+podman exec freepbx fwconsole r
+systemctl --user restart nethcti-server

--- a/imageroot/bin/module-cleanup-state
+++ b/imageroot/bin/module-cleanup-state
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+rm -rf db_backup asterisk_backup

--- a/imageroot/bin/module-dump-state
+++ b/imageroot/bin/module-dump-state
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+# clean container files on exit
+cleanup () {
+    podman exec mariadb rm -rf /tmp/db_backup
+    podman exec asterisk rm -f /var/lib/asterisk/db/astdb.sqlite3.dump
+}
+
+trap cleanup EXIT
+
+## MariaDB
+# exec mariabackup to save database in /tmp/db_backup
+podman exec mariadb \
+    mariabackup \
+        --backup \
+        --target-dir=/tmp/db_backup \
+        --user=root \
+        --password="${MARIADB_ROOT_PASSWORD}"
+# copy db_backup in local filesystem
+podman cp mariadb:/tmp/db_backup db_backup
+
+
+## Asterisk
+
+# /var/lib/asterisk/db/astdb.sqlite3.dump
+# /var/lib/asterisk/sounds/*/custom
+# /var/lib/asterisk/sounds/nethcti
+# /var/spool/asterisk/voicemail
+# /var/spool/asterisk/monitor
+
+# dump asterisk sqlite db
+podman exec asterisk backup_astdb
+# copy sqlite db to local filesystem
+mkdir -p asterisk_backup/var/lib/asterisk/db
+podman cp asterisk:/var/lib/asterisk/db/astdb.sqlite3.dump asterisk_backup/var/lib/asterisk/db/astdb.sqlite3.dump
+
+# copy only custom sounds
+sounds_dirs=$(podman exec asterisk find /var/lib/asterisk/sounds -type d -name custom)
+for dir in $sounds_dirs; do
+    mkdir -p "asterisk_backup$dir"
+    podman cp "asterisk:$dir/." "asterisk_backup$dir"
+done
+
+# copy nethcti sounds
+if podman exec asterisk ls -alh /var/lib/asterisk/sounds/nethcti >/dev/null 2>&1; then
+    mkdir -p asterisk_backup/var/lib/asterisk/sounds/nethcti
+    podman cp asterisk:/var/lib/asterisk/sounds/nethcti/. asterisk_backup/var/lib/asterisk/sounds/nethcti
+fi

--- a/imageroot/etc/state-include.conf
+++ b/imageroot/etc/state-include.conf
@@ -1,0 +1,10 @@
+state/db_backup
+volumes/asterisk
+volumes/moh
+volumes/lookup.d
+volumes/spool
+state/asterisk_backup
+volumes/tancredi
+volumes/pbooksources
+volumes/scripts
+volumes/post_scripts


### PR DESCRIPTION
Edits:
 - Moved MariaDB service start from module creation to module configuration
 - Added custom asterisk scripts for backup and restore of SQLite (I/O redirect in `podman exec` causes a lot of issues)
 - NS8 configuration
   - Added binaries for dump/cleanup
   - Added module-restore action
   - Added state-include.conf

Closes #61
