### PR TITLE
destroy-module: check if nethvoice's domain is set

### DIFF
--- a/imageroot/actions/destroy-module/60sip_proxy
+++ b/imageroot/actions/destroy-module/60sip_proxy
@@ -25,7 +25,11 @@ if proxy_id is None:
 
 print(f"Proxy id: {proxy_id}", file=sys.stderr) # debug
 
-# Configure nethvoice-proxy to route SIP traffic for Nethvoice
+# Remove nethvoice-proxy route
+if "NETHVOICE_HOST" not in os.environ:
+    print("WARNING: No hostname configured, skipping proxy's route remove", file=sys.stderr)
+    sys.exit(0)
+
 response = agent.tasks.run(
     agent_id=proxy_id,
     action='remove-route',


### PR DESCRIPTION
Before try to remove the proxy's route check if the variable NETHVOICE_HOST was set by the `configure-module` action