### PR TITLE
Disable tancredi http2https

### DIFF
--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -80,7 +80,7 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-provisioning',
         'url':  'http://127.0.0.1:' + os.environ["TANCREDIPORT"] + '/provisioning',
-        'http2https':  "false",
+        'http2https':  False,
         'lets_encrypt': lets_encrypt,
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/provisioning',

--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -63,7 +63,7 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-tancredi',
         'url':  'http://127.0.0.1:' + os.environ["TANCREDIPORT"] + '/tancredi',
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'http2https':  "false",
         'lets_encrypt': lets_encrypt,
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/tancredi',
@@ -80,7 +80,7 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-provisioning',
         'url':  'http://127.0.0.1:' + os.environ["TANCREDIPORT"] + '/provisioning',
-        'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
+        'http2https':  "false",
         'lets_encrypt': lets_encrypt,
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/provisioning',

--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -63,7 +63,7 @@ response = agent.tasks.run(
     data={
         'instance': os.environ['MODULE_ID'] + '-tancredi',
         'url':  'http://127.0.0.1:' + os.environ["TANCREDIPORT"] + '/tancredi',
-        'http2https':  "false",
+        'http2https':  False,
         'lets_encrypt': lets_encrypt,
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/tancredi',


### PR DESCRIPTION
Tancredi API are called by nethcti-server or by phones, both calls it in HTTP and shouldn't be redirected to HTTPS because 
- nethcti-server is local
- if phones use HTTP is because they couldn't use HTTPS