### PR TITLE
configure-module: fix proxy's route address

### DIFF
--- a/imageroot/actions/configure-module/60sip_proxy
+++ b/imageroot/actions/configure-module/60sip_proxy
@@ -27,7 +27,7 @@ response = agent.tasks.run(
     action='add-route',
     data={
         'domain': os.environ["NETHVOICE_HOST"],
-        'address': [{"uri":"sip:127.0.0.1:"+os.environ["ASTERISK_SIP_PORT"],"description":os.environ["MODULE_ID"]}],
+        'address': [{"uri":"sip:"+ ksrv[0]["host"] +":"+os.environ["ASTERISK_SIP_PORT"],"description":os.environ["MODULE_ID"]}],
     },
 )
 

--- a/tests/00_nethvoice_install_dependencies.robot
+++ b/tests/00_nethvoice_install_dependencies.robot
@@ -19,3 +19,5 @@ Check if nethvoice-proxy is installed correctly
     Set Global Variable    ${proxy_module_id}    ${output.module_id}
     Run task    cluster/alter-repository    {"name": "default", "status": true, "testing": true}
     ...    rc_expected=0
+    Run task    module/${proxy_module_id}/configure-module
+    ...    {"addresses": {"address": "1.2.3.4"}}

--- a/tests/10_nethvoice_actions/10_configure_integrations.robot
+++ b/tests/10_nethvoice_actions/10_configure_integrations.robot
@@ -19,3 +19,20 @@ Check if nethvoice is configured as expected
 Check if the password can be changed
     ${response} =  Run task    module/${module_id}/set-nethvoice-admin-password   
     ...    {"nethvoice_admin_password": "Nethesis,1234"}
+
+Check if the route on nethvoice-proxy is created correctly
+    ${response} =  Run task    module/${module_id}/list-service-providers
+    ...    {"service": "sip", "transport": "tcp", "filter": {"module_id": "${proxy_module_id}"} }
+    ${proxy_addr} =  Set Variable   ${response[0]['host']}
+    ${response} =  Run task    module/${proxy_module_id}/get-route
+    ...    {"domain": "voice.ns8.local"}
+    Should Contain    ${response['address'][0]['uri']}    ${proxy_addr}
+
+    Run task    module/${proxy_module_id}/configure-module
+    ...    {"addresses": {"address": "5.6.7.8"}}
+    ${response} =  Run task    module/${module_id}/list-service-providers
+    ...    {"service": "sip", "transport": "tcp", "filter": {"module_id": "${proxy_module_id}"} }
+    ${proxy_addr} =  Set Variable   ${response[0]['host']}
+    ${response} =  Run task    module/${proxy_module_id}/get-route
+    ...    {"domain": "voice.ns8.local"}
+    Should Contain    ${response['address'][0]['uri']}    ${proxy_addr}


### PR DESCRIPTION
The proxy and the instance of the NethVocie module are in the same node, for correct routing, kamailio needs the destination address of the route to be the same as the address from where the SIP traffic is aspected.

nethesis/ns8-nethvoice#100