### PR TITLE
freepbx: fix broken ca certs path

### DIFF
--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -88,10 +88,6 @@ EOF
 
 chown asterisk:asterisk /var/lib/asterisk/db
 
-# Setup ca bundle for pjsip
-ln -sf /etc/pki/tls/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
-
-
 # Customized wizard page
 cat > /etc/apache2/sites-available/wizard.conf <<EOF
 AliasMatch ^/(?!freepbx)(.+)$ /var/www/html/freepbx/wizard/\$1


### PR DESCRIPTION
The original fix was made before the merge Asterisk and FreePBX
containers, it is no longer needed,

Original commit: https://github.com/nethesis/ns8-nethvoice/commit/43fbd1b60a92fc56f48f83bfc0e5e6be17c387b0
