### PR TITLE
actions: add `get-facts` action

### DIFF
--- a/imageroot/actions/get-facts/10get_facts
+++ b/imageroot/actions/get-facts/10get_facts
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import subprocess
+import os
+import sys
+import agent
+
+counter_script=f"""
+podman exec mariadb mariadb {os.environ['AMPDBNAME']}  -uroot  -p{os.environ['MARIADB_ROOT_PASSWORD']} -BN \
+  -e "SELECT COUNT(*) FROM userman_users WHERE default_extension != 'none' UNION ALL SELECT COUNT(*) FROM rest_devices_phones WHERE type = 'mobile';"
+"""
+
+nethvoice_users = {}
+
+try:
+    with subprocess.Popen(counter_script, stdout=subprocess.PIPE, shell=True, text=True) as fcounter:
+        res = fcounter.stdout.read().split('\n')
+        nethvoice_users['nethvoice_users_count'] = int(res[0])
+        nethvoice_users['nethvoice_mobile_users_count'] = int(res[1])
+
+except Exception as ex:
+    print(agent.SD_ERR, ex, file=sys.stderr)
+
+json.dump(nethvoice_users, fp=sys.stdout)

--- a/tests/10_nethvoice_actions/10_get-facts_integrations.robot
+++ b/tests/10_nethvoice_actions/10_get-facts_integrations.robot
@@ -1,0 +1,10 @@
+*** Settings ***
+Library    SSHLibrary
+Resource  ../api.resource
+
+*** Test Cases ***
+Check if the factc are returned as expected
+    ${response} =  Run task    module/${module_id}/get-facts    {}
+    Should Be Equal As Integers    ${response['nethvoice_users_count']}    0
+    Should Be Equal As Integers    ${response['nethvoice_mobile_users_count']}    0
+


### PR DESCRIPTION
The `get-facts` action will collect metrics about the NethVoice module. Currently, the exposed metrics are:

  - `nethvoice_users_count`: Number of main extensions created
  - `nethvoice_mobile_users_count`: Number of main extensions with the mobile app enabled
 
#127 