### PR TITLE
configure-module: restart services when needed

### DIFF
--- a/imageroot/actions/configure-module/20setenvs
+++ b/imageroot/actions/configure-module/20setenvs
@@ -7,6 +7,7 @@
 
 import json
 import sys
+import os
 
 import agent
 
@@ -44,3 +45,34 @@ getFromRequest(request, 'nethcti_ui_host', 'NETHCTI_UI_HOST', '')
 getFromRequest(request, 'nethcti_ui_product_name', 'NETHCTI_UI_PRODUCT_NAME', 'NethVoice CTI')
 getFromRequest(request, 'nethcti_ui_company_name', 'NETHCTI_UI_COMPANY_NAME', 'Nethesis')
 getFromRequest(request, 'nethcti_ui_company_url', 'NETHCTI_UI_COMPANY_URL', 'https://www.nethesis.it/')
+
+#Check if the services must be restarted
+agent.set_env('RESTART_SERVICES', '')
+services_to_restart = set()
+if 'nethvoice_host' in request and os.getenv('NETHVOICE_HOST') != request['nethvoice_host']:
+    services_to_restart.add('freepbx.service')
+    services_to_restart.add('flexisip.service')
+    services_to_restart.add('nethcti-ui.service')
+    services_to_restart.add('reports-api.service')
+    services_to_restart.add('reports-ui.service')
+    services_to_restart.add('tancredi.service')
+
+if 'reports_international_prefix' in request and os.getenv('REPORTS_INTERNATIONAL_PREFIX') != request['reports_international_prefix']:
+    services_to_restart.add('reports-api.service')
+    services_to_restart.add('reports-ui.service')
+
+if 'timezone' in request and os.getenv('TIMEZONE') != request['timezone']:
+    services_to_restart.add('freepbx.service')
+    services_to_restart.add('flexisip.service')
+    services_to_restart.add('janus.service')
+    services_to_restart.add('mariadb.service')
+    services_to_restart.add('nethcti-ui.service')
+    services_to_restart.add('phonebook.service')
+    services_to_restart.add('redis-flexisip.service')
+    services_to_restart.add('reports-api.service')
+    services_to_restart.add('reports-redis.service')
+    services_to_restart.add('reports-ui.service')
+    services_to_restart.add('tancredi.service')
+    services_to_restart.add('nethcti-server.service')
+
+agent.set_env('RESTART_SERVICES', ' '.join(services_to_restart))

--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -8,6 +8,12 @@
 set -e    # exit immediately if an error occurs
 exec 1>&2 # ensure any output is sent to stderr
 
+#restart services if they are already running
+
+if [ -n "$RESTART_SERVICES" ]; then
+systemctl --user try-restart $RESTART_SERVICES
+fi
+
 # If the control reaches this step, the service can be enabled and started
 
 systemctl --user enable --now mariadb.service
@@ -22,8 +28,6 @@ systemctl --user enable --now watcher.path
 systemctl --user enable --now redis-flexisip.service
 systemctl --user enable --now flexisip.service
 # Reports
-systemctl --user enable reports-api.service
-systemctl --user restart reports-api.service
+systemctl --user enable --now reports-api.service
 systemctl --user enable --now reports-scheduler.timer
 systemctl --user enable --now reports-ui.service
-systemctl --user restart reports-ui.service


### PR DESCRIPTION
If the values of the input attributes are different from the values stored in the associated environment variables, the relative services will be restarted.

Currently checked attributes:
  * `nethvoice_host`
  * `reports_international_prefix`
  * `timezone`