### PR TITLE
systemd: ignore image volumes on `reports-redis`

### DIFF
--- a/imageroot/systemd/user/reports-redis.service
+++ b/imageroot/systemd/user/reports-redis.service
@@ -21,6 +21,7 @@ ExecStart=/usr/bin/podman run \
 	--publish=127.0.0.1:${REPORTS_REDIS_PORT}:6379 \
 	--health-cmd "redis-cli --raw incr ping" \
 	--tz=${TIMEZONE} \
+        --image-volume=ignore \
 	${REDIS_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id


### PR DESCRIPTION
The `/data` volume defined in the upstream `redis` image is not used and it creates an orphanage anonymous volume every service restart. Also, anonymous volumes are not supported by the NS8 move/clone procedure.

https://github.com/nethesis/ns8-nethvoice/issues/171