### PR TITLE
update-module.d: set proxy's parameters variables

### DIFF
--- a/imageroot/update-module.d/10env
+++ b/imageroot/update-module.d/10env
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+
+# Set the proxy IP and port if not already set and the proxy is installed
+if os.getenv('PROXY_IP') is None or os.getenv('PROXY_PORT') is None:
+    proxy_id = agent.resolve_agent_id('nethvoice-proxy@node')
+    if proxy_id is not None:
+        ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip", "tcp", {"module_id": proxy_id.removeprefix("module/")})
+        agent.set_env("PROXY_IP", ksrv[0]["host"])
+        agent.set_env("PROXY_PORT", ksrv[0]["port"])


### PR DESCRIPTION
`PROXY_IP` and `PROXY_PORT` variables are created by the `configure-module` action. In case of an update from a version where those variables were not present, we have to create them during the update procedure.