### PR TITLE
freepbx: update outbound_proxy parameter format

### DIFF
--- a/freepbx/initdb.d/initdb.php
+++ b/freepbx/initdb.d/initdb.php
@@ -101,7 +101,7 @@ $db->query($sql);
 
 // Set proxy ip and port in VoIP provider default settings
 if (!empty($_ENV['PROXY_IP']) && !empty($_ENV['PROXY_PORT'])) {
-	$sql = 'UPDATE `asterisk`.`rest_pjsip_trunks_defaults` SET `data` = ? WHERE `data` = ? AND `keyword` = "outbound_proxy"';
+	$sql = 'UPDATE `asterisk`.`rest_pjsip_trunks_defaults` SET `data` = ? AND `keyword` = "outbound_proxy"';
 	$stmt = $db->prepare($sql);
-	$stmt->execute(['sip:'.$_ENV['PROXY_IP'].':'.$_ENV['PROXY_PORT'],'sip:127.0.0.1:5060']);
+	$stmt->execute(['sip:'.$_ENV['PROXY_IP'].':'.$_ENV['PROXY_PORT'].';lr']);
 }

--- a/freepbx/initdb.d/migration.php
+++ b/freepbx/initdb.d/migration.php
@@ -52,7 +52,7 @@ if (count($res) > 0) {
 
 	$sql = "UPDATE `asterisk`.`sip` SET `data` = ? WHERE `keyword` = 'outbound_proxy' AND `id` IN ($qm_string)";
 	$stmt = $db->prepare($sql);
-	$stmt->execute(array_merge(['sip:'.$proxy_host.':'.$proxy_port], array_column($res, 'extension')));
+	$stmt->execute(array_merge(['sip:'.$proxy_host.':'.$proxy_port.';lr'], array_column($res, 'extension')));
 
 	# set rtp_symmetric to no in freepbx sip table
 	$sql = "UPDATE `asterisk`.`sip` SET `data` = 'no' WHERE `keyword` = 'rtp_symmetric' WHERE `id` IN ($qm_string)";
@@ -121,7 +121,7 @@ $sip_options=[
 	'force_rport' => 'no',
 	'maximum_expiration' => '7200',
 	'media_encryption' => 'no',
-	'outbound_proxy' => 'sip:'.$_ENV['PROXY_IP'].':'.$_ENV['PROXY_PORT'],
+	'outbound_proxy' => 'sip:'.$_ENV['PROXY_IP'].':'.$_ENV['PROXY_PORT'].';lr',
 	'qualifyfreq' => '60',
 	'rewrite_contact' => 'no',
 	'rtp_symmetric' => 'no',


### PR DESCRIPTION
To support the NAT topology, the outbound proxy's URI must have the `;lr` (Loose Routing) parameter.

nethesis/ns8-nethvoice#156