### PR TITLE
events: update proxy configuration

### DIFF
--- a/imageroot/events/nethvoice-proxy-settings-changed/00validate_event
+++ b/imageroot/events/nethvoice-proxy-settings-changed/00validate_event
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import agent
+import os
+
+
+# Check if NethVoice is configured
+if os.getenv('NETHVOICE_HOST') is None:
+    print(agent.SD_DEBUG + "Event ignored: NethVoice is not configured")
+    sys.exit(2)
+
+event = json.load(sys.stdin)
+
+# Check if the event is for this node
+if event['node_id'] != os.environ['NODE_ID']:
+    print(agent.SD_DEBUG + "Event ignored: node_id mismatch")
+    sys.exit(3)
+
+ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip", "tcp", {"module_id": os.environ['AGENT_EVENT_SOURCE'].removeprefix("module/")})
+
+
+# Check if there is something changed in the configuration
+if (os.getenv('NETHVOICE_PROXY_FQDN') == ksrv[0]["fqdn"] and
+    os.getenv('PROXY_IP') == ksrv[0]["host"] and
+    os.getenv('PROXY_PORT') == ksrv[0]["port"]):
+    print(agent.SD_DEBUG + "Event ignored: configuration not changed")
+    sys.exit(4)

--- a/imageroot/events/nethvoice-proxy-settings-changed/20configure_proxy
+++ b/imageroot/events/nethvoice-proxy-settings-changed/20configure_proxy
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+
+ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip", "tcp", {"module_id": os.environ['AGENT_EVENT_SOURCE'].removeprefix("module/")})
+
+# Update the configuration
+agent.set_env('NETHVOICE_PROXY_FQDN', ksrv[0]["fqdn"])
+agent.set_env('PROXY_IP', ksrv[0]["host"])
+agent.set_env('PROXY_PORT', ksrv[0]["port"])
+
+# Configure nethvoice-proxy to route SIP traffic for Nethvoice
+response = agent.tasks.run(
+    agent_id=os.environ['AGENT_EVENT_SOURCE'],
+    action='add-route',
+    data={
+        'domain': os.environ['NETHVOICE_HOST'],
+        'address': [{"uri":"sip:"+ ksrv[0]["host"] +":"+os.environ["ASTERISK_SIP_PORT"],"description":os.environ["MODULE_ID"]}],
+    },
+)
+
+# Check if proxy configuration has been successfull
+agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/events/nethvoice-proxy-settings-changed/80start_services
+++ b/imageroot/events/nethvoice-proxy-settings-changed/80start_services
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e    # exit immediately if an error occurs
+exec 1>&2 # ensure any output is sent to stderr
+
+#restart services if they are already running
+
+systemctl --user try-restart freepbx tancredi


### PR DESCRIPTION
When the FQDN, IP, or port of the proxy are changed, update the
environment variables, adjust the proxy route, and restart freepbx and
tancredi services.
