### PR TITLE
actions: support external users domain provider

### DIFF
--- a/imageroot/actions/configure-module/30traefik
+++ b/imageroot/actions/configure-module/30traefik
@@ -180,19 +180,22 @@ agent.assert_exp(response['exit_code'] == 0)
 # Get users admin srv records
 ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "users-admin", "http", {"domain": data["user_domain"]})
 
-# Configure Traefik to route "/users-admin" path requests to the user portal service
-response = agent.tasks.run(
-    agent_id=agent.resolve_agent_id('traefik@node'),
-    action='set-route',
-    data={
-        'instance': os.environ['MODULE_ID'] + '-users-admin',
-        'url': ksrv[0]["url"],
-        'http2https':  True,
-        'lets_encrypt': lets_encrypt,
-        'host': os.environ["NETHVOICE_HOST"],
-        'path': '/users-admin/' + data["user_domain"],
-        'strip_prefix': True,
-    },
-)
+# Check if users admin service is available
+if len(ksrv) > 0:
 
-agent.assert_exp(response['exit_code'] == 0)
+    # Configure Traefik to route "/users-admin" path requests to the user portal service
+    response = agent.tasks.run(
+        agent_id=agent.resolve_agent_id('traefik@node'),
+        action='set-route',
+        data={
+            'instance': os.environ['MODULE_ID'] + '-users-admin',
+            'url': ksrv[0]["url"],
+            'http2https':  True,
+            'lets_encrypt': lets_encrypt,
+            'host': os.environ["NETHVOICE_HOST"],
+            'path': '/users-admin/' + data["user_domain"],
+            'strip_prefix': True,
+        },
+    )
+
+    agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/configure-module/validate-input.json
+++ b/imageroot/actions/configure-module/validate-input.json
@@ -31,9 +31,7 @@
     "required": [
         "nethvoice_host",
         "nethcti_ui_host",
-        "reports_international_prefix",
-        "nethvoice_adm_username",
-        "nethvoice_adm_password"
+        "reports_international_prefix"
     ],
     "properties": {
         "nethvoice_host_local_networks": {

--- a/imageroot/actions/destroy-module/20destroy
+++ b/imageroot/actions/destroy-module/20destroy
@@ -40,5 +40,3 @@ for service in services:
             'instance': f"{os.environ['MODULE_ID']}-{service}"
         },
     )
-    # Check if traefik configuration has been successfull
-    agent.assert_exp(response['exit_code'] == 0)

--- a/imageroot/actions/destroy-module/80cleanup_user_domain
+++ b/imageroot/actions/destroy-module/80cleanup_user_domain
@@ -16,3 +16,6 @@ TOKEN=$(curl -k -s "https://$(hostname -f)/users-admin/${USER_DOMAIN}/api/login"
 
 # Remove the user
 curl -s -k "https://$(hostname -f)/users-admin/$USER_DOMAIN/api/remove-user" -H "authorization: Bearer $TOKEN" --data '{"user":"'$NETHVOICE_USER_PORTAL_USERNAME'"}' > /dev/null
+
+# Don't fail if domain is an external one
+exit 0


### PR DESCRIPTION
If the user's domain provider is external, it's not possible to manage the users directly, and the user manager portal is not available. So the following changes are made:

* Create the user manager HTTP rule only if the service is available.
* Don't request the admin's account provider credentials as mandatory.
* On module destroy, don't fail if an HTTP route doesn't exist or if the cleanup of account provider admin users is not possible.


