### PR TITLE
configure-module: check the type of subscription

### DIFF
--- a/imageroot/actions/configure-module/21subscription
+++ b/imageroot/actions/configure-module/21subscription
@@ -12,9 +12,14 @@ rdb = agent.redis_connect(privileged=False)
 
 subscription = rdb.hgetall('cluster/subscription')
 
-# Check if the subscription hash table exists
-if subscription:
+# Check if the subscription hash table exists and if the provider is nsent
+if subscription and subscription['provider'] == "nsent":
     # Get the subscription secret
     agent.set_env("SUBSCRIPTION_SECRET", subscription['auth_token'])
     # Get subscription ID
     agent.set_env("SUBSCRIPTION_SYSTEMID", subscription['system_id'])
+else:
+    # Unset the subscription secret
+    agent.set_env("SUBSCRIPTION_SECRET" , "")
+    # Unset subscription ID
+    agent.set_env("SUBSCRIPTION_SYSTEMID", "")


### PR DESCRIPTION
Only set the subscription variable if it comes from `nsent`; otherwise, the credentials will not be valid to access additional external services.
