### PR TITLE
freepbx: get user domain from USER_DOMAIN env var

### DIFF
--- a/freepbx/configure_users.php
+++ b/freepbx/configure_users.php
@@ -153,7 +153,7 @@ $stmt->execute([$id, json_encode($ldap_settings), $id]);
 echo $ldap_settings['name'] . " userbase configuration: " . json_encode($ldap_settings) . "\n";
 
 // Check if domain changed and clean extensions
-$stmt = $db->prepare('SELECT `value` FROM `freepbx_settings` WHERE `keyword` = "NETHVOICE_LDAP_DOMAIN"');
+$stmt = $db->prepare('SELECT `value` FROM `freepbx_settings` WHERE `keyword` = "USER_DOMAIN"');
 $stmt->execute();
 $old_domain = $stmt->fetchColumn();
 
@@ -175,9 +175,9 @@ $extensions_destinations_table_field = array(
 );
 
 if (empty($old_domain) && !empty($_ENV['NETHVOICE_LDAP_BASE'])) {
-	$db->prepare('INSERT IGNORE INTO `freepbx_settings` (`keyword`, `value`, `name`, `level`, `description`, `type`, `options`, `defaultval`,`readonly`,`hidden`,`category`,`module`,`emptyok`,`sortorder`) VALUES ("NETHVOICE_LDAP_DOMAIN", ?, "Name of NethVoice user base domain", 0, "This is automatically configured at FreePBX container startup using environment NETHVOICE_LDAP_ variables", "text", "", "",1,1,"System Setup","",1,0)')->execute([$_ENV['NETHVOICE_LDAP_DOMAIN']]);
+	$db->prepare('INSERT IGNORE INTO `freepbx_settings` (`keyword`, `value`, `name`, `level`, `description`, `type`, `options`, `defaultval`,`readonly`,`hidden`,`category`,`module`,`emptyok`,`sortorder`) VALUES ("USER_DOMAIN", ?, "Name of NethVoice user base domain", 0, "This is automatically configured at FreePBX container startup using environment NETHVOICE_LDAP_ variables", "text", "", "",1,1,"System Setup","",1,0)')->execute([$_ENV['USER_DOMAIN']]);
 } elseif ($old_domain !== $_ENV['NETHVOICE_LDAP_BASE']) {
-	$db->prepare('UPDATE `freepbx_settings` SET `value` = ? WHERE `keyword` = "NETHVOICE_LDAP_DOMAIN"')->execute([$_ENV['NETHVOICE_LDAP_DOMAIN']]);
+	$db->prepare('UPDATE `freepbx_settings` SET `value` = ? WHERE `keyword` = "USER_DOMAIN"')->execute([$_ENV['USER_DOMAIN']]);
 	// Clean extensions
 	$stmt = $db->prepare('SELECT `extension` FROM `users`');
 	$stmt->execute();

--- a/imageroot/actions/configure-module/50users
+++ b/imageroot/actions/configure-module/50users
@@ -29,7 +29,6 @@ if domparams['host'] != os.getenv('NETHVOICE_LDAP_HOST', '') or \
     services_to_restart.add('freepbx.service')
 agent.set_env('RESTART_SERVICES', ' '.join(services_to_restart))
 
-agent.set_env('NETHVOICE_LDAP_DOMAIN', domain)
 agent.set_env('NETHVOICE_LDAP_HOST', domparams['host'])
 agent.set_env('NETHVOICE_LDAP_PORT', domparams['port'])
 agent.set_env('NETHVOICE_LDAP_USER', domparams['bind_dn'])

--- a/imageroot/systemd/user/freepbx.service
+++ b/imageroot/systemd/user/freepbx.service
@@ -66,6 +66,7 @@ ExecStart=/usr/bin/podman run \
     --env=PROXY_PORT \
     --env=NETHVOICE_USER_PORTAL_USERNAME \
     --env=NETHVOICE_USER_PORTAL_PASSWORD \
+    --env=USER_DOMAIN \
     --network=host \
     --tz=${TIMEZONE} \
     --hostname=${NETHVOICE_HOST} \


### PR DESCRIPTION
The NETHVOICE_LDAP_DOMAIN environment variable is not created after a module update. This can lead to missing user domain changes if the user changes the user domain before invoking the configure action at least once with the old user domain.
