### PR TITLE
Enhancements and Fixes for Module Cloning and State Transfer Procedures

### DIFF
--- a/imageroot/actions/clone-module/20start_mariadb_service
+++ b/imageroot/actions/clone-module/20start_mariadb_service
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+# Read the source environment file
+env_clone = agent.read_envfile('environment.clone-module')
+
+# Set the old asterisk database password in the environment file
+agent.set_env('AMPDBPASS', env_clone['AMPDBPASS'])
+
+# Start the MariaDB service
+agent.run_helper(*'systemctl --user start mariadb.service'.split()).check_returncode()
+
+# Restore asterisk database password in the environment file
+agent.set_env('AMPDBPASS', os.environ['AMPDBPASS'])

--- a/imageroot/actions/clone-module/21set_mariadb_passwords
+++ b/imageroot/actions/clone-module/21set_mariadb_passwords
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+# Read the source environment file
+env_clone = agent.read_envfile('environment.clone-module')
+
+# Set new mariadb root password
+SQL_QUERY = f"""
+ALTER USER 'root'@'localhost' IDENTIFIED BY '{os.environ['MARIADB_ROOT_PASSWORD']}';
+ALTER USER 'root'@'%' IDENTIFIED BY '{os.environ['MARIADB_ROOT_PASSWORD']}';
+FlUSH PRIVILEGES;
+"""
+agent.run_helper(*f'podman exec mariadb mysql -u root -p{env_clone["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()
+
+# Set the new passwords
+agent.run_helper(*f'podman exec -e AMPDBPASS={os.environ["AMPDBPASS"]} mariadb /docker-entrypoint-initdb.d/90_users.sh'.split()).check_returncode()

--- a/imageroot/actions/clone-module/22set_db_services_ports
+++ b/imageroot/actions/clone-module/22set_db_services_ports
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+# Set new service ports
+
+# SQL query to update kvstore_Sipsettings
+SQL_QUERY = f"""
+UPDATE `kvstore_Sipsettings`
+SET `val` = CASE
+    WHEN `key` = 'udpport-0.0.0.0' THEN '{os.environ['ASTERISK_SIP_PORT']}'
+    WHEN `key` = 'tlsport-0.0.0.0' THEN '{os.environ['ASTERISK_SIPS_PORT']}'
+    WHEN `key` = 'tcpport-0.0.0.0' THEN '{os.environ['ASTERISK_SIP_PORT']}'
+END
+WHERE `key` IN ('udpport-0.0.0.0', 'tlsport-0.0.0.0', 'tcpport-0.0.0.0');
+"""
+agent.run_helper(*f'podman exec mariadb mysql asterisk -u root -p{os.environ["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()
+
+# SQL query to update freepbx_settings
+SQL_QUERY = f"""
+UPDATE `freepbx_settings`
+SET `value` = '{os.environ['ASTMANAGERPORT']}',
+    `name` = 'Asterisk Manager Port',
+    `level` = 2,
+    `description` = 'Port for the Asterisk Manager',
+    `type` = 'int',
+    `options` = '1024,65535',
+    `defaultval` = '{os.environ['ASTMANAGERPORT']}',
+    `readonly` = 1,
+    `hidden` = 0,
+    `category` = 'Asterisk Manager',
+    `module` = '',
+    `emptyok` = 0,
+    `sortorder` = 0
+WHERE `keyword` = 'ASTMANAGERPORT'
+"""
+agent.run_helper(*f'podman exec mariadb mysql asterisk -u root -p{os.environ["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()
+
+# SQL query to update kvstore_Sipsettings with bindport and tlsbindport
+SQL_QUERY = f"""
+UPDATE `kvstore_Sipsettings`
+SET `val` = CASE
+    WHEN `key` = 'bindport' THEN '{os.environ['ASTERISK_SIP_PORT']}'
+    WHEN `key` = 'tlsbindport' THEN '{os.environ['ASTERISK_SIPS_PORT']}'
+END
+WHERE `key` IN ('bindport', 'tlsbindport');
+"""
+agent.run_helper(*f'podman exec mariadb mysql asterisk -u root -p{os.environ["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()
+
+# SQL query to update iaxsettings
+SQL_QUERY = f"""
+UPDATE `iaxsettings`
+SET `data` = '{os.environ['ASTERISK_IAX_PORT']}',
+    `seq` = 1,
+    `type` = 0
+WHERE `keyword` = 'bindport';
+"""
+agent.run_helper(*f'podman exec mariadb mysql asterisk -u root -p{os.environ["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()
+
+# SQL query to update sipsettings
+SQL_QUERY = f"""
+UPDATE `sipsettings`
+SET `data` = '{os.environ['ASTERISK_SIP_PORT']}',
+    `seq` = 1,
+    `type` = 0
+WHERE `keyword` = 'bindport';
+"""
+agent.run_helper(*f'podman exec mariadb mysql asterisk -u root -p{os.environ["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()
+
+# SQL query to update freepbx_settings for HTTPTLSENABLE
+SQL_QUERY = f"""
+UPDATE `freepbx_settings`
+SET `value` = '0',
+    `name` = 'Enable TLS for the mini-HTTP Server',
+    `level` = 3,
+    `description` = 'Enables listening for HTTPS connections. This is for Asterisk, it is not directly related for FreePBX usage and the value of this setting is irrelevant for accessing core FreePBX settings. Default is no.',
+    `type` = 'bool',
+    `options` = '',
+    `defaultval` = '0',
+    `readonly` = 0,
+    `hidden` = 0,
+    `category` = 'Asterisk Builtin mini-HTTP server',
+    `module` = '',
+    `emptyok` = 0,
+    `sortorder` = 0
+WHERE `keyword` = 'HTTPTLSENABLE';
+"""
+agent.run_helper(*f'podman exec mariadb mysql asterisk -u root -p{os.environ["MARIADB_ROOT_PASSWORD"]} -e'.split(), SQL_QUERY).check_returncode()

--- a/imageroot/actions/clone-module/23stop_mariadb_service
+++ b/imageroot/actions/clone-module/23stop_mariadb_service
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+
+# Stop the MariaDB service
+agent.run_helper(*'systemctl --user stop mariadb.service'.split()).check_returncode()

--- a/imageroot/actions/clone-module/30clean_env
+++ b/imageroot/actions/clone-module/30clean_env
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+
+# Cleanup the environment
+agent.unset_env('NETHVOICE_USER_PORTAL_PASSWORD')
+agent.unset_env('NETHVOICE_USER_PORTAL_USERNAME')
+agent.unset_env('RESTART_SERVICES')

--- a/imageroot/actions/transfer-state/49stop_services
+++ b/imageroot/actions/transfer-state/49stop_services
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# Read the list of services to stop from the `./default-target.clone-module` file
+services=$(cat default-target.clone-module | sed -e 's/watcher.path//g' -e 's/agent.service//g')
+
+# Wait for the services to be stopped
+systemctl --user stop $services


### PR DESCRIPTION
This pull request includes several improvements and fixes related to the module cloning process and state transfer procedures:

- **Reconfigured Service Ports:** Ensures that new service ports assigned after module cloning are correctly set in the database.
- **Environment Variable Cleanup:** Removes unnecessary environment variables as part of the module cloning process.
- **MariaDB Password Reset:** Resets the MariaDB passwords to ensure they are different from the original module instance after cloning.
- **Graceful Service Shutdown:** Ensures that NethVoice services are gracefully shut down before terminating the containers' volume transfer.

After the clone/move, the module must be reconfigured via `configure-module` to be fully operational.

https://github.com/nethesis/ns8-nethvoice/issues/210