### PR TITLE
nethcti-server. StaticPath: Fixed wrong static path

### DIFF
--- a/nethcti-server/entrypoint.sh
+++ b/nethcti-server/entrypoint.sh
@@ -331,7 +331,7 @@ cat > $FILE <<EOF
     "static": {
       "port": "${NETHCTI_INTERNAL_REST_PORT5}",
       "address": "localhost",
-      "webroot": "/usr/lib/node/nethcti-server/plugins/com_static_http/static",
+      "webroot": "/app/plugins/com_static_http/static",
       "customWebroot": "/var/lib/nethserver/nethcti/static"
     },
     "voicemail": {


### PR DESCRIPTION
On click of `/webrest/historycall/down_callrec/` post API inside CTI, server log returns this error: `Error: ENOENT: no such file or directory, open '/usr/lib/node/nethcti-server/plugins/com_static_http/static/`  it means that path is wrong, new path is `/app/plugins/com_static_http/static`