### PR TITLE
take asterisk audio files from github instead of asterisksounds

### DIFF
--- a/freepbx/Containerfile
+++ b/freepbx/Containerfile
@@ -232,7 +232,11 @@ RUN mkdir download \
     && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-es.tar.gz \
     && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-fr.tar.gz \
     && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-it.tar.gz \
-    && tar xzvf asterisk-sounds-??.tar.gz -C /var/lib/asterisk/sounds
+    && tar xzvf asterisk-sounds-de.tar.gz -C /var/lib/asterisk/sounds \
+    && tar xzvf asterisk-sounds-en.tar.gz -C /var/lib/asterisk/sounds \
+    && tar xzvf asterisk-sounds-es.tar.gz -C /var/lib/asterisk/sounds \
+    && tar xzvf asterisk-sounds-fr.tar.gz -C /var/lib/asterisk/sounds \
+    && tar xzvf asterisk-sounds-it.tar.gz -C /var/lib/asterisk/sounds \
     && chown -R asterisk:asterisk /var/lib/asterisk/sounds \
     && cd .. && rm -rf download
 

--- a/freepbx/Containerfile
+++ b/freepbx/Containerfile
@@ -226,27 +226,13 @@ RUN chown asterisk:asterisk \
 
 RUN mkdir download \
     && cd download \
-    && mkdir -p /var/lib/asterisk/sounds/it \
-    && mkdir -p /var/lib/asterisk/sounds/en \
-    && mkdir -p /var/lib/asterisk/sounds/es \
-    && mkdir -p /var/lib/asterisk/sounds/de \
-    && mkdir -p /var/lib/asterisk/sounds/fr \
     && mkdir -p /var/lib/asterisk/sounds/nethcti \
-    && wget -nv https://github.com/nethesis/nethvoice-langs/releases/download/2.0.0/asterisk-sounds-core-it-2.11.1.zip \
-    && wget -nv https://github.com/nethesis/nethvoice-langs/releases/download/2.0.0/asterisk-sounds-extra-it-2.11.1.zip \
-    && unzip -o 'asterisk-sounds-*-it-*.zip' -d /var/lib/asterisk/sounds/it \
-    && wget -nv --no-check-certificate http://www.asterisksounds.org/sites/asterisksounds.org/files/sounds/es-ES/download/asterisk-sounds-core-es-ES-2.9.15.zip \
-    && wget -nv --no-check-certificate https://www.asterisksounds.org/sites/asterisksounds.org/files/sounds/es-ES/download/asterisk-sounds-extra-es-ES-2.9.15.zip \
-    && unzip -o 'asterisk-sounds-*-es-*.zip' -d /var/lib/asterisk/sounds/es \
-    && wget -nv --no-check-certificate https://www.asterisksounds.org/sites/asterisksounds.org/files/sounds/fr-FR/download/asterisk-sounds-core-fr-FR-2.3.10.zip \
-    && wget -nv --no-check-certificate https://www.asterisksounds.org/sites/asterisksounds.org/files/sounds/fr-FR/download/asterisk-sounds-extra-fr-FR-2.3.10.zip \
-    && unzip -o 'asterisk-sounds-*-fr-*.zip' -d /var/lib/asterisk/sounds/fr \
-    && wget -nv --no-check-certificate https://www.asterisksounds.org/sites/asterisksounds.org/files/sounds/de/download/asterisk-sounds-core-de-2.11.19.zip \
-    && wget -nv --no-check-certificate https://www.asterisksounds.org/sites/asterisksounds.org/files/sounds/de/download/asterisk-sounds-extra-de-2.11.19.zip \
-    && unzip -o 'asterisk-sounds-*-de-*.zip' -d /var/lib/asterisk/sounds/de \
-    && wget -nv --no-check-certificate https://github.com/nethesis/nethvoice-langs/releases/download/2.0.0/asterisk-sounds-core-en-2.11.1.zip \
-    && wget -nv --no-check-certificate https://github.com/nethesis/nethvoice-langs/releases/download/2.0.0/asterisk-sounds-extra-en-2.11.1.zip \
-    && unzip -o 'asterisk-sounds-*-en-*.zip' -d /var/lib/asterisk/sounds/en \
+    && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-de.tar.gz \
+    && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-en.tar.gz \
+    && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-es.tar.gz \
+    && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-fr.tar.gz \
+    && wget -nv https://github.com/nethesis/ns8-nethvoice/releases/download/0.0.1-rc.2.0.2/asterisk-sounds-it.tar.gz \
+    && tar xzvf asterisk-sounds-??.tar.gz -C /var/lib/asterisk/sounds
     && chown -R asterisk:asterisk /var/lib/asterisk/sounds \
     && cd .. && rm -rf download
 
@@ -257,7 +243,6 @@ COPY var/lib/asterisk /var/lib/asterisk
 COPY usr/bin/backup_astdb /usr/bin/backup_astdb
 COPY usr/bin/restore_astdb /usr/bin/restore_astdb
 COPY usr/local/bin/import-certificate /usr/local/bin/import-certificate
-
 
 RUN mkdir -p \
 	/etc/phonebook/sources.d/ \


### PR DESCRIPTION
This fix build failure because of asterisksounds.org being expired