### PR TITLE
remove checkUsermanIsUnlocked()

### DIFF
--- a/freepbx/var/www/html/freepbx/rest/lib/csvimport.php
+++ b/freepbx/var/www/html/freepbx/rest/lib/csvimport.php
@@ -129,22 +129,17 @@ try {
 
         # create extension
         if (isset($row[2]) && preg_match('/^[0-9]+$/',$row[2])) {
-            if (checkUsermanIsUnlocked()) {
-                $create = createMainExtensionForUser($username,$row[2]);
-                if ($create !== true) {
-                    $result += 1;
-                    $err .= "Error adding main extension ".$row[2]." to user ".$username.": ".$create['message']."\n";
-                } else {
-                    // assign physical device to user if it is a migration
-                    if (function_exists('isMigration') && isMigration()) {
-                        $secret = getOldSecret($row[2]);
-                        $extension = createExtension($row[2],false);
-                        useExtensionAsCustomPhysical($extension,$secret,'temporaryphysical');
-                    }
-                }
+            $create = createMainExtensionForUser($username,$row[2]);
+            if ($create !== true) {
+                $result += 1;
+                $err .= "Error adding main extension ".$row[2]." to user ".$username.": ".$create['message']."\n";
             } else {
-                $err .= "Error adding main extension ".$row[2]." to user ".$username.": directory is locked";
-                continue;
+                // assign physical device to user if it is a migration
+                if (function_exists('isMigration') && isMigration()) {
+                    $secret = getOldSecret($row[2]);
+                    $extension = createExtension($row[2],false);
+                    useExtensionAsCustomPhysical($extension,$secret,'temporaryphysical');
+                }
             }
         }
 

--- a/freepbx/var/www/html/freepbx/rest/lib/libExtensions.php
+++ b/freepbx/var/www/html/freepbx/rest/lib/libExtensions.php
@@ -997,7 +997,11 @@ function updateUsermanUser($username, $mainextension = 'none') {
                 include($amp_conf['AMPWEBROOT']."/admin/modules/userman/functions.inc/auth/modules/".$directory['driver'].".php");
             }
             $d = new $class($fpbx->Userman, $fpbx, $directory['config']);
-            return $d->updateUser($uid, $username, $username, $mainextension, null, array(), null, false);
+            $status = $d->updateUser($uid, $username, $username, $mainextension, null, array(), null, false);
+            if ($status['status'] == false) {
+                error_log(__FUNCTION__ . 'ERROR: ' . $status['message']);
+            }
+            return $status;
         }
     }
 }

--- a/freepbx/var/www/html/freepbx/rest/lib/libExtensions.php
+++ b/freepbx/var/www/html/freepbx/rest/lib/libExtensions.php
@@ -985,7 +985,7 @@ function getProvisioningEngine() {
     return 'tancredi';
 }
 
-function updateUsermanUser($username, $mainextension = null) {
+function updateUsermanUser($username, $mainextension = 'none') {
     global $amp_conf;
     $fpbx = FreePBX::create();
     $uid = $fpbx->Userman->getUserByUsername($username)['id'];

--- a/freepbx/var/www/html/freepbx/rest/lib/libExtensions.php
+++ b/freepbx/var/www/html/freepbx/rest/lib/libExtensions.php
@@ -986,15 +986,15 @@ function getProvisioningEngine() {
 }
 
 function updateUsermanUser($username, $mainextension = null) {
+    global $amp_conf;
     $fpbx = FreePBX::create();
-    $dbh = FreePBX::Database();
     $uid = $fpbx->Userman->getUserByUsername($username)['id'];
     $u = $fpbx->Userman->getUserByID($uid);
     foreach ($fpbx->Userman->getAllDirectories() as $directory) {
         if ($directory['id'] == $u['auth']) {
             $class = 'FreePBX\modules\Userman\Auth\\'.$directory['driver'];
             if(!class_exists($class)) {
-                include("/var/www/html/freepbx/admin/modules/userman/functions.inc/auth/modules/".$directory['driver'].".php");
+                include($amp_conf['AMPWEBROOT']."/admin/modules/userman/functions.inc/auth/modules/".$directory['driver'].".php");
             }
             $d = new $class($fpbx->Userman, $fpbx, $directory['config']);
             return $d->updateUser($uid, $username, $username, $mainextension, null, array(), null, false);

--- a/freepbx/var/www/html/freepbx/rest/modules/mainextensions.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/mainextensions.php
@@ -48,18 +48,14 @@ $app->post('/mainextensions', function (Request $request, Response $response, $a
     $mainextension = $params['extension'];
     $outboundcid = $params['outboundcid'];
 
-    if (checkUsermanIsUnlocked()) {
-        if (
-            configuredUsersCount() >= communityUsersLimit() && // check if there are more configured users than the allowed limit
-            (empty($_ENV['SUBSCRIPTION_SYSTEMID']) || empty($_ENV['SUBSCRIPTION_SECRET'])) && // it isn't registered as enterprise
-            !empty($mainextension) // the user is trying to create a new extension
-        ) {
-            return $response->withJson(array("status"=>'ERROR: community version is limited to 8 users'), 403);
-        }
-        $ret = createMainExtensionForUser($username,$mainextension,$outboundcid);
-    } else {
-        return $response->withJson(array("status"=>'ERROR: directory is locked'), 500);
+    if (
+        configuredUsersCount() >= communityUsersLimit() && // check if there are more configured users than the allowed limit
+        (empty($_ENV['SUBSCRIPTION_SYSTEMID']) || empty($_ENV['SUBSCRIPTION_SECRET'])) && // it isn't registered as enterprise
+        !empty($mainextension) // the user is trying to create a new extension
+    ) {
+        return $response->withJson(array("status"=>'ERROR: community version is limited to 8 users'), 403);
     }
+        $ret = createMainExtensionForUser($username,$mainextension,$outboundcid);
 
     system('/var/www/html/freepbx/rest/lib/retrieveHelper.sh > /dev/null &');
 


### PR DESCRIPTION
Instead of checking for userman syncing ad fail if it's locked, call the update low level function without checks.

If directory is syncing, it isn't possible to update extensions into userman table, so Wizard checks for userman directory lock before changing a mainextension. But syncing can take a lot of time and if there are a lot of users this make user page in wizard not usable.

Is lock checking really neded? If directory is locked, the [updateUser](https://github.com/FreePBX/userman/blob/e168ce938ff8d94b066a38e76478a7eb92cbee63/Userman.class.php#L2564) function [fails](https://github.com/FreePBX/userman/blob/e168ce938ff8d94b066a38e76478a7eb92cbee63/Userman.class.php#L2594) but why? In the cases of AD/LDAP, it shouldn't be really an issue because tue updateUser [calls](https://github.com/FreePBX/userman/blob/e168ce938ff8d94b066a38e76478a7eb92cbee63/Userman.class.php#L2616C45-L2616C55) the driver updateUser that just  update mysql. 

So can we call driver updateUser without checking for syncing? it seems so.

This needs to be tested very well