### PR TITLE
systemd: add customer_card volume

### DIFF
--- a/imageroot/systemd/user/freepbx.service
+++ b/imageroot/systemd/user/freepbx.service
@@ -25,6 +25,7 @@ ExecStart=/usr/bin/podman run \
     --volume=spool:/var/spool/asterisk:z \
     --volume=asterisk:/etc/asterisk:z \
     --volume=nethcti:/etc/nethcti:z \
+    --volume=customer_card:/var/lib/nethserver/nethcti/templates/customer_card/:z \
     --volume=sounds:/var/lib/asterisk/sounds:z \
     --volume=moh:/var/lib/asterisk/moh:z \
     --volume=agi-bin:/var/lib/asterisk/agi-bin:z \

--- a/imageroot/systemd/user/nethcti-server.service
+++ b/imageroot/systemd/user/nethcti-server.service
@@ -26,6 +26,7 @@ ExecStart=/usr/bin/podman run \
     --volume=nethcti-server:/root:Z \
     --volume=nethcti-server-code:/usr/lib/node/nethcti-server:Z \
     --volume=nethcti-server-cert:/etc/certificates:z \
+    --volume=customer_card:/var/lib/nethserver/nethcti/templates/customer_card/:z \
     --volume=sounds:/var/lib/asterisk/sounds:z \
     --volume=spool:/var/spool/asterisk:z \
     --volume=reports_config:/opt/nethvoice-report:z \


### PR DESCRIPTION
The custom customer card templates will be stored in the `customer_card` volume, and the volume will be shared between the `freepbx` and `nethcti-server` containers.

https://github.com/nethesis/ns8-nethvoice/issues/263