### PR TITLE
Change CF for CTI voicemail status

### DIFF
--- a/freepbx/var/www/html/freepbx/admin/modules/nethcti3/functions.inc.php
+++ b/freepbx/var/www/html/freepbx/admin/modules/nethcti3/functions.inc.php
@@ -116,6 +116,8 @@ function nethcti3_get_config_late($engine) {
             /* Add wakeup for App*/
             $ext->splice('macro-dial-one', 's','setexttocall', new ext_agi('/var/lib/asterisk/agi-bin/app_wakeup.php'));
             $ext->splice('macro-dial', 's', 'dial', new ext_agi('/var/lib/asterisk/agi-bin/app_wakeup.php'));
+	    /* Change CF for CTI voicemail status */
+	    $ext->replace('macro-dial-one', 'cf', '2', new ext_execif('$["${DB(AMPUSER/${DB_RESULT}/cidnum)}" == "" && "${DB_RESULT:0:2}" != "vm"]', 'Set','__REALCALLERIDNUM=${DEXTEN}'));
 
             /* Use main extension on login/logout/pause*/
             if (!empty(\FreePBX::Queues()->listQueues())) {


### PR DESCRIPTION
In NethVoice CTI if the voicemail status is active the CF is to vmuXXX.
Added check if transfer recipient is voicemail in vmuXXX format because in that case the caller is incorrectly obtained.
