### PR TITLE
Fix log tag of freepbx.service

### DIFF
--- a/imageroot/systemd/user/freepbx.service
+++ b/imageroot/systemd/user/freepbx.service
@@ -20,7 +20,6 @@ ExecStart=/usr/bin/podman run \
     --conmon-pidfile=%t/freepbx.pid \
     --cidfile=%t/freepbx.ctr-id \
     --cgroups=no-conmon \
-    --log-opt=tag=nethvoice \
     --replace --name=%N \
     --volume=spool:/var/spool/asterisk:z \
     --volume=asterisk:/etc/asterisk:z \


### PR DESCRIPTION
The %u is expanded to the module ID, e.g. `nethvoice5`, which is duplicated in Loki label `module_id`. Since we have a label for the application, the syslog tag can identify the service in the application context. Here `nethvoice` (or `freepbx`) are fine.

Example in Logs page:

    2024-08-01T15:56:32+02:00 [9:nethvoice5:nethvoice5] Got a Janus API request from janus.transport.http (0x7f222404a1e0)
    
With the proposed change it becomes:

    2024-08-01T15:56:32+02:00 [9:nethvoice5:nethvoice] Got a Janus API request from janus.transport.http (0x7f222404a1e0)
    
As alternative, remove the --log-tag option completely to obtain

    2024-08-01T15:56:32+02:00 [9:nethvoice5:freepbx] Got a Janus API request from janus.transport.http (0x7f222404a1e0)