### PR TITLE
mariadb: fix missing semicolon

### DIFF
--- a/mariadb/docker-entrypoint-initdb.d/50_asterisk.kvstore_Sipsettings.sql
+++ b/mariadb/docker-entrypoint-initdb.d/50_asterisk.kvstore_Sipsettings.sql
@@ -84,4 +84,4 @@ INSERT INTO `kvstore_Sipsettings` (`key`,`val`,`type`,`id`) VALUES
 ("tlsdomain-0.0.0.0","",NULL,"noid"),
 ("tlsextip-0.0.0.0","",NULL,"noid"),
 ("tlslocalnet-0.0.0.0","",NULL,"noid"),
-("pjsip.identifers.order","[\"EI_ip\",\"EI_username\",\"EI_anonymous\",\"EI_header\",\"EI_auth_username\"]",NULL,"noid"),
+("pjsip.identifers.order","[\"EI_ip\",\"EI_username\",\"EI_anonymous\",\"EI_header\",\"EI_auth_username\"]",NULL,"noid");


### PR DESCRIPTION
Correctly terminate the SQL query in one of the database initialization scripts.

Typo introduced by PR: https://github.com/nethesis/ns8-nethvoice/pull/287.
