### PR TITLE
Added missing TIMEZONE variable inside nethcti-server unit

### DIFF
--- a/imageroot/systemd/user/nethcti-server.service
+++ b/imageroot/systemd/user/nethcti-server.service
@@ -46,6 +46,7 @@ ExecStart=/usr/bin/podman run \
     --env=CDRDBPASS \
     --env=SUBSCRIPTION_SYSTEMID \
     --env=SUBSCRIPTION_SECRET \
+    --env=TIMEZONE=${TIMEZONE} \
     --network=host \
     --tz=${TIMEZONE} \
     ${NETHVOICE_CTI_SERVER_IMAGE}


### PR DESCRIPTION
In order for the change made in the PR to work: https://github.com/nethesis/nethcti-server/pull/316, need to add a TIMEZONE environment variable