### PR TITLE
Fix queue manager permission at startup

### DIFF
--- a/freepbx/freepbx_init.sh
+++ b/freepbx/freepbx_init.sh
@@ -103,4 +103,4 @@ php -r 'include_once "/etc/freepbx_db.conf"; $db->query("UPDATE freepbx_settings
 fwconsole userman --syncall --force --verbose
 
 # Always apply changes on start
-su - asterisk -s /bin/sh -c "/var/lib/asterisk/bin/fwconsole reload"
+su asterisk -s /bin/sh -c "/var/lib/asterisk/bin/fwconsole reload"


### PR DESCRIPTION
Launching reload with "-" simulate login so the environment isn't passed to the fwconsole reload. The subscription variables are in the environment and if they aren't seen by fwconsole qmanager assume the server isn't registered and disable qmanager
https://github.com/NethServer/dev/issues/7041