### PR TITLE
Avoid timeout on mariadb service initialization

### DIFF
--- a/imageroot/actions/create-module/50mariadb-init
+++ b/imageroot/actions/create-module/50mariadb-init
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+podman run \
+    --rm \
+    --replace \
+    --name=mariadb-init \
+    --volume=mariadb-data:/var/lib/mysql:Z \
+    --env-file=./passwords.env \
+    --env=NETHVOICE_MARIADB_PORT \
+    --env=AMPDBUSER \
+    --env=CDRDBUSER \
+    --env=CDRDBHOST \
+    --env=CTIUSER \
+    --env=NETHCTI_DB_USER \
+    --env=PHONEBOOK* \
+    --env=ASTERISK_RTPSTART \
+    --env=ASTERISK_RTPEND \
+    --env=ASTERISK_SIP_PORT \
+    --env=ASTERISK_SIPS_PORT \
+    --env=ASTERISK_IAX_PORT \
+    --env=ASTMANAGERPORT \
+    ${NETHVOICE_MARIADB_IMAGE}

--- a/imageroot/actions/import-module/40mysql
+++ b/imageroot/actions/import-module/40mysql
@@ -7,6 +7,9 @@
 
 set -e
 
+# remove the mysql volume (done by create-module)
+podman volume rm -f  mariadb-data
+
 # Add users, fixes and permissions
 cat - > ./restore/99permissions.sh <<'EOF'
 #!/bin/bash

--- a/imageroot/actions/restore-module/21database
+++ b/imageroot/actions/restore-module/21database
@@ -7,6 +7,9 @@
 
 set -e
 
+# remove the mysql volume (done by create-module)
+podman volume rm -f  mariadb-data
+
 # prepare restore
 podman run \
     --rm \

--- a/mariadb/docker-entrypoint-initdb.d/99_stop_mariadb_import.sh
+++ b/mariadb/docker-entrypoint-initdb.d/99_stop_mariadb_import.sh
@@ -1,5 +1,10 @@
 # Prepare the script that stops the container
 # The .sh file is sourced by the Bash entrypoint script
 # because it is not an executable file:
+mysql_note "Stopping temporary server"
 docker_temp_server_stop # function defined by the entrypoint script
+mysql_note "Temporary server stopped"
+echo
+mysql_note "MariaDB init process done. Ready for start up."
+echo
 exit 0 # exit the entrypoint immediately: do not start the real DB server

--- a/mariadb/docker-entrypoint-initdb.d/99_stop_mariadb_import.sh
+++ b/mariadb/docker-entrypoint-initdb.d/99_stop_mariadb_import.sh
@@ -1,0 +1,5 @@
+# Prepare the script that stops the container
+# The .sh file is sourced by the Bash entrypoint script
+# because it is not an executable file:
+docker_temp_server_stop # function defined by the entrypoint script
+exit 0 # exit the entrypoint immediately: do not start the real DB server


### PR DESCRIPTION
The pull request includes several changes to the MariaDB initialization and module configuration scripts. the main is the init of mariadb during the create-module action

Overall, these changes improve the MariaDB initialization and module configuration process, making it more efficient and avoid to hit the systemd timeout for mariadb service on slow machine

https://github.com/NethServer/dev/issues/7078