### PR TITLE
action: release module on PR merge to main

### DIFF
--- a/.github/workflows/create-testing-release.yml
+++ b/.github/workflows/create-testing-release.yml
@@ -11,8 +11,7 @@ jobs:
   release-module:
     if: >
       github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'main' &&
-      !contains(github.event.pull_request.labels.*.name, 'translation')
+      github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/create-testing-release.yml
+++ b/.github/workflows/create-testing-release.yml
@@ -3,6 +3,14 @@ name: NS8 Release on PR Merge to Main
 on:
   pull_request:
     types: [closed]
+    paths-ignore:
+      - '.github/**'
+      - 'tests/**'
+      - 'README.md'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'renovate.json'
+      - 'test-module.sh'
 
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-testing-release.yml
+++ b/.github/workflows/create-testing-release.yml
@@ -1,0 +1,23 @@
+name: NS8 Release on PR Merge to Main
+
+on:
+  pull_request:
+    types: [closed]
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  release-module:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      !contains(github.event.pull_request.labels.*.name, 'translation')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install NS8 Release Module Extension
+        run: gh extension install NethServer/gh-ns8-release-module
+
+      - name: Create Testing Release
+        run: gh ns8-release-module create --repo ${{ github.repository }} --testing


### PR DESCRIPTION
Add a new GitHub Action workflow that automatically creates testing releases when a pull request is merged into the main branch. The workflow:
- Triggers only on merged PRs to main branch
- Ignores changes to documentation and CI files
- Uses [gh-ns8-release-module](https://github.com/NethServer/gh-ns8-release-module) extension to create testing releases