### PR TITLE
feat: add support session user management scripts

### DIFF
--- a/imageroot/events/support-session-started/10add_support_user
+++ b/imageroot/events/support-session-started/10add_support_user
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+read -r support_user session_id < <(jq -r '[.support_user, .session_id] | join("\t")')
+
+# Check if support_user and session_id arguments are provided
+if [ -z "$support_user" ] || [ -z "$session_id" ]; then
+	exit 1
+fi
+
+podman exec mariadb bash -c '
+	mysql -u root -p$MARIADB_ROOT_PASSWORD asterisk -e "
+	INSERT INTO ampusers (username, password_sha1, sections) 
+	VALUES (\"'"$support_user"'\", SHA1(\"'"$session_id"'\"), \"*\") 
+	ON DUPLICATE KEY UPDATE password_sha1=SHA1(\"'"$session_id"'\")
+	"'

--- a/imageroot/events/support-session-stopped/10remove_support_user
+++ b/imageroot/events/support-session-stopped/10remove_support_user
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2024 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+exec 1>&2
+set -e
+
+# Parse JSON and set variables
+read -r support_user < <(jq -r '.support_user')
+
+# Check if support_user argument is provided
+if [ -z "$support_user" ]; then
+  echo "Error: missing support_user argument."
+  exit 1
+fi
+
+podman exec mariadb bash -c '
+	mysql -u root -p$MARIADB_ROOT_PASSWORD asterisk -e "
+	DELETE FROM ampusers WHERE username = \"'"$support_user"'\""'
+


### PR DESCRIPTION
- Add script to create support user upon session start (`10add_support_user`).
- Add script to remove support user upon session stop (`10remove_support_user`).

These scripts handle support user creation and deletion by interacting with the database, ensuring temporary users are managed appropriately for support sessions.

https://github.com/NethServer/dev/issues/7096