### PR TITLE
feat(container): import Redis image for reports

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -33,6 +33,6 @@ LABEL org.nethserver.images="${REPOBASE}/nethvoice-mariadb:${IMAGETAG} \
     ${REPOBASE}/nethvoice-tancredi:${IMAGETAG} \
     ${REPOBASE}/nethvoice-janus:${IMAGETAG} \
     ${REPOBASE}/nethvoice-phonebook:${IMAGETAG} \
-    docker.io/library/redis:7.0.10-alpine \
+    ${REPOBASE}/nethvoice-reports-redis:${IMAGETAG} \
     ${REPOBASE}/nethvoice-reports-ui:${IMAGETAG} \
     ${REPOBASE}/nethvoice-reports-api:${IMAGETAG}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -141,6 +141,17 @@ buildah build --force-rm --layers --jobs "$(nproc)" --target ui-production \
 images+=("${repobase}/${reponame}")
 popd
 
+#########################
+##      Redis	      ##
+#########################
+echo "[*] Build Reports Redis container"
+reponame="nethvoice-reports-redis"
+container=$(buildah from docker.io/library/redis:7.0.10-alpine)
+# Commit the image
+buildah commit "${container}" "${repobase}/${reponame}"
+buildah commit "${container}" "${repobase}/${reponame}:${IMAGETAG:-latest}"
+# Append the image URL to the images array
+images+=("${repobase}/${reponame}")
 
 # Setup CI when pushing to Github.
 # Warning! docker::// protocol expects lowercase letters (,,)

--- a/imageroot/systemd/user/reports-redis.service
+++ b/imageroot/systemd/user/reports-redis.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/podman run \
 	--health-cmd "redis-cli --raw incr ping" \
 	--tz=${TIMEZONE} \
         --image-volume=ignore \
-	${REDIS_IMAGE}
+	${NETHVOICE_REPORTS_REDIS_IMAGE}
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ExecStopPost=/usr/bin/podman rm -f --ignore --cidfile=%t/%n.ctr-id
 Type=notify


### PR DESCRIPTION
Refactor the Containerfile, build script, and service file to
incorporate the new `nethvoice-reports-redis` container image.
This change removes direct references to `docker.io` to avoid
encountering rate limiting during module installation.

https://github.com/NethServer/dev/issues/7169
