### PR TITLE
fix(freepbx_init.sh): install  modules as asterisk user

### DIFF
--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -207,6 +207,16 @@ CheckInterval: 20
 EOF
 fi
 
+# create freepbx chown configuration if it doesn't exist
+if [[ ! -f /etc/asterisk/freepbx_chown.conf ]]; then
+  cat > /etc/asterisk/freepbx_chown.conf <<EOF
+[blacklist]
+directory = /var/www/html/freepbx/rest
+directory = /var/www/html/freepbx/visualplan
+directory = /var/www/html/freepbx/wizard
+EOF
+fi
+
 # configure recallonbusy
 sed -i 's/^Port: .*/Port: '${ASTMANAGERPORT}'/' /etc/asterisk/recallonbusy.cfg
 sed -i 's/^Username: .*/Username: proxycti/' /etc/asterisk/recallonbusy.cfg

--- a/freepbx/etc/asterisk/freepbx_chown.conf
+++ b/freepbx/etc/asterisk/freepbx_chown.conf
@@ -1,0 +1,4 @@
+[blacklist]
+directory = /var/www/html/freepbx/rest
+directory = /var/www/html/freepbx/visualplan
+directory = /var/www/html/freepbx/wizard

--- a/freepbx/freepbx_init.sh
+++ b/freepbx/freepbx_init.sh
@@ -80,7 +80,7 @@ for module in \
 do
     if ! test -s "$module_status" || grep -q "$module " "$module_status" && ! grep -q "$module Enabled" "$module_status" ; then
         echo Installing module $module
-        fwconsole moduleadmin install $module
+        su asterisk -s /bin/sh -c "/var/lib/asterisk/bin/fwconsole moduleadmin install $module"
     fi
 done
 

--- a/freepbx/freepbx_init.sh
+++ b/freepbx/freepbx_init.sh
@@ -96,6 +96,9 @@ do
     fi
 done
 
+# Fix permissions
+fwconsole chown
+
 # Disable signature check
 php -r 'include_once "/etc/freepbx_db.conf"; $db->query("UPDATE freepbx_settings SET value = 0 WHERE keyword = \"SIGNATURECHECK\"");'
 

--- a/freepbx/freepbx_init.sh
+++ b/freepbx/freepbx_init.sh
@@ -80,7 +80,7 @@ for module in \
 do
     if ! test -s "$module_status" || grep -q "$module " "$module_status" && ! grep -q "$module Enabled" "$module_status" ; then
         echo Installing module $module
-        su asterisk -s /bin/sh -c "/var/lib/asterisk/bin/fwconsole moduleadmin install $module"
+        fwconsole moduleadmin install $module
     fi
 done
 


### PR DESCRIPTION
- Use asterisk user instead of root to install module at first start
- This should avoid random bug that prevent freepbx reload untill container is restarted

https://github.com/NethServer/dev/issues/7191