### PR TITLE
Implement ICE Enforcement Configuration

### DIFF
--- a/imageroot/actions/configure-module/61ice_enforce
+++ b/imageroot/actions/configure-module/61ice_enforce
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+import agent
+import agent.tasks
+
+services_to_restart = set(os.environ['RESTART_SERVICES'].split())
+
+# Get proxy srv records
+proxy_id = agent.resolve_agent_id('nethvoice-proxy@node')
+ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip", "tcp", {"module_id": proxy_id.removeprefix("module/")})
+
+# Configure ICE to enforce the proxy ip address.
+# Restart services to apply new configuration if needed
+if os.environ["ICEENFORCE"] != ksrv[0]["address"]:
+    agent.set_env("ICEENFORCE", ksrv[0]["address"])
+    services_to_restart.add("janus.service")
+
+agent.set_env("RESTART_SERVICES", " ".join(services_to_restart))

--- a/imageroot/actions/create-module/05setenvs
+++ b/imageroot/actions/create-module/05setenvs
@@ -123,6 +123,7 @@ agent.set_env('ASTERISK_RTPEND', sip_end)
 agent.set_env('STUNSERVER', 'stun1.l.google.com')
 agent.set_env('STUNPORT', 19302)
 agent.set_env('ICEIGNORE', 'vmnet,tap,tun,virb,vb-')
+agent.set_env('ICEENFORCE', 'none')
 
 agent.set_env('TRAEFIK_HTTP2HTTPS', 'true')
 

--- a/imageroot/events/nethvoice-proxy-settings-changed/20configure_proxy
+++ b/imageroot/events/nethvoice-proxy-settings-changed/20configure_proxy
@@ -15,6 +15,7 @@ ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip"
 agent.set_env('NETHVOICE_PROXY_FQDN', ksrv[0]["fqdn"])
 agent.set_env('PROXY_IP', ksrv[0]["host"])
 agent.set_env('PROXY_PORT', ksrv[0]["port"])
+agent.set_env("ICEENFORCE", ksrv[0]["address"])
 
 # Configure nethvoice-proxy to route SIP traffic for Nethvoice
 response = agent.tasks.run(

--- a/imageroot/events/nethvoice-proxy-settings-changed/80start_services
+++ b/imageroot/events/nethvoice-proxy-settings-changed/80start_services
@@ -10,4 +10,4 @@ exec 1>&2 # ensure any output is sent to stderr
 
 #restart services if they are already running
 
-systemctl --user try-restart freepbx tancredi
+systemctl --user try-restart freepbx tancredi janus

--- a/imageroot/systemd/user/janus.service
+++ b/imageroot/systemd/user/janus.service
@@ -32,6 +32,7 @@ ExecStart=/usr/bin/podman run \
     --configs-folder=/usr/local/etc/janus \
     --interface=lo \
     --ice-ignore-list=${ICEIGNORE} \
+    --ice-enforce-list=${ICEENFORCE} \
     --stun-server=${STUNSERVER}:${STUNPORT} \
     --rtp-port-range=${JANUS_RTPSTART}-${JANUS_RTPEND} \
     --cert-pem=/etc/certificates/NethServer.pem \

--- a/imageroot/update-module.d/10env
+++ b/imageroot/update-module.d/10env
@@ -63,3 +63,6 @@ if not os.path.exists("passwords.env"):
 # Set the brand site and docs static URLs
 agent.set_env('BRAND_SITE', 'https://www.nethesis.it/soluzioni/nethvoice')
 agent.set_env('BRAND_DOCS', 'https://docs.nethserver.org/projects/ns8/it/latest/nethvoice.html')
+
+if os.getenv('ICEENFORCE') is None:
+    agent.set_env('ICEENFORCE', 'none')

--- a/janus/README.md
+++ b/janus/README.md
@@ -6,6 +6,7 @@ Janus-gateway container for NethServer 8
 
 - `LOCAL_IP` local IP address to bind to for SIP stack and media
 - `JANUS_RTPSTART` and `JANUS_RTPEND` are the UDP port range for RTP packages
+- `ICEENFORCE` list of interfaces or ip addresses to enforce ICE candidates gathering. Default is 'none'
 - `ICEIGNORE` list of interfaces to ignore. Default is 'vmnet,tap,tun,virb,vb-' https://github.com/meetecho/janus-gateway#configure-and-start
 - `STUNSERVER` STUN server. Default is stun1.l.google.com
 - `STUNPORT` STUN port. Default is 19302


### PR DESCRIPTION
This pull request adds the ability to enforce ICE candidates with the proxy IP
address. It introduces a new environment variable, `ICEENFORCE`, which is set
to the proxy IP address. The `janus.service` is also updated to include the
`--ice-enforce-list` option, allowing the enforcement of ICE candidates on
specific interfaces or IP addresses. Additionally, the `create-module` and
`update-module` actions are modified to include the `ICEENFORCE` variable
enforcement behavior.

https://github.com/NethServer/dev/issues/7099
