### PR TITLE
fix(clone-module): correct env-file syntax

### DIFF
--- a/imageroot/actions/clone-module/21set_mariadb_passwords
+++ b/imageroot/actions/clone-module/21set_mariadb_passwords
@@ -20,4 +20,4 @@ FlUSH PRIVILEGES;
 agent.run_helper(*f'podman exec mariadb mysql -u root -p{MARIADB_ROOT_PASSWORD_OLD} -e'.split(), SQL_QUERY).check_returncode()
 
 # Set the new passwords
-agent.run_helper(*f'podman exec --env-file="passwords.env" mariadb /docker-entrypoint-initdb.d/90_users.sh'.split()).check_returncode()
+agent.run_helper(*f'podman exec --env-file=passwords.env mariadb /docker-entrypoint-initdb.d/90_users.sh'.split()).check_returncode()


### PR DESCRIPTION
The `--env-file` argument was previously enclosed in quotes, which could
cause issues when the command is executed. This change removes the
unnecessary quotes to ensure that the environment variables are
correctly passed to the `podman exec` command.
