### PR TITLE
fix: set correct ownership for customer_card volume in entrypoint

### DIFF
--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -87,7 +87,7 @@ Description = ODBC on asteriskcdrdb
 EOF
 
 mkdir -p /var/spool/asterisk/outgoing /var/spool/asterisk/tmp /var/spool/asterisk/uploads 
-chown asterisk:asterisk /var/lib/asterisk/db /var/spool/asterisk/outgoing /var/spool/asterisk/tmp /var/spool/asterisk/uploads
+chown asterisk:asterisk /var/lib/asterisk/db /var/spool/asterisk/outgoing /var/spool/asterisk/tmp /var/spool/asterisk/uploads /var/lib/nethserver/nethcti/templates/customer_card
 
 # Customized wizard page
 cat > /etc/apache2/sites-available/wizard.conf <<EOF


### PR DESCRIPTION
Change the owner of the volume `/var/lib/nethserver/nethcti/templates/customer_card` to `asterisk:asterisk` in the entrypoint. This ensures the NethVoice wizard can add new customer cards without permission issues.

https://github.com/NethServer/dev/issues/7219