### PR TITLE
fix(proxy): prevent adding proxy to trunk identity0 for TIM

### DIFF
--- a/freepbx/initdb.d/migration.php
+++ b/freepbx/initdb.d/migration.php
@@ -85,6 +85,7 @@ $sql = "UPDATE `asterisk`.`pjsip`
 		FROM `asterisk`.`pjsip` as pjsip_inner
 		WHERE `pjsip_inner`.`keyword` = 'trunk_name'
 		AND `pjsip_inner`.`data` NOT LIKE '%custom%'
+		AND `pjsip_inner`.`data` NOT LIKE '%identity0%'
 	)";
 
 $stmt = $db->prepare($sql);


### PR DESCRIPTION
Ensures that the proxy is not added to the trunk named `identity0` for TIM trunks certification.
https://github.com/NethServer/dev/issues/7247