### PR TITLE
fix(wizard-api): return null with 200 instead of 404 for unconfigured items

### DIFF
--- a/freepbx/var/www/html/freepbx/rest/modules/mobiles.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/mobiles.php
@@ -49,7 +49,7 @@ $app->get('/mobiles/{username}', function (Request $request, Response $response,
           ' WHERE userman_users.username = \''. $username. '\'';
         $mobile = $dbh->sql($sql, 'getOne', \PDO::FETCH_ASSOC);
         if ($mobile == false) {
-            return $response->withStatus(404);
+            return $response->withJson(null,200);
         }
 
         return $response->withJson($mobile, 200);

--- a/freepbx/var/www/html/freepbx/rest/modules/nethlink.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/nethlink.php
@@ -32,7 +32,7 @@ $app->get('/nethlink/{mainextension}', function (Request $request, Response $res
     if (!empty($extension)) {
         return $response->withJson($extension, 200);
     } else {
-        return $response->withStatus(404);
+        return $response->withJson(null,200);
     }
 });
 

--- a/freepbx/var/www/html/freepbx/rest/modules/physicalextensions.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/physicalextensions.php
@@ -204,7 +204,7 @@ $app->get('/mobileapp/{mainextension}', function (Request $request, Response $re
     if (!empty($extension)) {
         return $response->withJson($extension, 200);
     } else {
-        return $response->withStatus(404);
+        return $response->withJson(null,200);
     }
 });
 

--- a/freepbx/var/www/html/freepbx/rest/modules/voicemails.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/voicemails.php
@@ -41,7 +41,7 @@ $app->get('/voicemails/{extension}', function (Request $request, Response $respo
         $res = FreePBX::Voicemail()->getVoicemail();
 
         if (is_array($res['default']) && !array_key_exists($extension, $res['default'])) {
-          return $response->withStatus(404);
+          return $response->withJson(null,200);
         }
 
         return $response->withJson($res['default'][$extension], 200);

--- a/freepbx/var/www/html/freepbx/rest/modules/webrtc.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/webrtc.php
@@ -32,7 +32,7 @@ $app->get('/webrtc/{mainextension}', function (Request $request, Response $respo
     if (!empty($extension)) {
         return $response->withJson($extension, 200);
     } else {
-        return $response->withStatus(404);
+        return $response->withJson(null,200);
     }
 });
 


### PR DESCRIPTION
Updated the following endpoints to return null and HTTP status 200 when no configured items are found:
- GET /mobiles/{mainextension}
- GET /mobileapp/{mainextension}
- GET /nethlink/{mainextension}
- GET /webrtc/{mainextension}
- GET /voicemails/{extension}

https://github.com/NethServer/dev/issues/7259