### PR TITLE
fix(systemd): fix env vars with special chars

### DIFF
--- a/imageroot/systemd/user/freepbx.service
+++ b/imageroot/systemd/user/freepbx.service
@@ -15,7 +15,7 @@ Restart=always
 ExecStartPre=/bin/rm -f %t/freepbx.pid %t/freepbx.ctr-id
 ExecStartPre=-runagent install-certificate freepbx
 ExecStartPre=-runagent discover-smarthost
-ExecStart=/usr/bin/podman run \
+ExecStart=runagent /usr/bin/podman run \
     --detach \
     --conmon-pidfile=%t/freepbx.pid \
     --cidfile=%t/freepbx.ctr-id \


### PR DESCRIPTION
Resolve issue with environment variables containing special characters when
loaded via systemd. Adjusted `ExecStart` to invoke `podman` through `runagent`,
ensuring proper handling of systemd's variable parsing quirks.

https://github.com/NethServer/dev/issues/7254
