### PR TITLE
fix(voicemail): prevent duplicated Content-Type in email

### DIFF
--- a/freepbx/var/lib/asterisk/bin/send_email
+++ b/freepbx/var/lib/asterisk/bin/send_email
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Read from standard input, remove "Date: " header, and pipe to s-nail
-sed '/^Date: /d' | s-nail -t
+sed '/^Date: \|Content-Type: /d' | s-nail -t


### PR DESCRIPTION
The problem appears to be caused by the presence of two Content-Type headers in the email message.
Upon examining the email headers, the rule MULTIPLE_UNIQUE_HEADERS was triggered due to the presence of duplicate Content-Type headers:
```
Content-Type: multipart/mixed; boundary="----voicemail_1350712061221135"
Content-Type: text/plain; charset=utf-8
```
According to email standards (RFC 2045 and RFC 5322), an email should have only one valid Content-Type header for the entire message.

Since Content-Type, as Date header, is automatically added by s-nail, this PR ensures that only a single Content-Type header is present in the email removing the one that arrives from standard input