### PR TITLE
fix(sftp): Add portsadm permission on the node to open sftp port on update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ COPY imageroot /imageroot
 # copy ui from ui_builder
 COPY --from=ui_builder /app/dist /ui
 ENTRYPOINT [ "/" ]
-LABEL org.nethserver.authorizations="traefik@any:fulladm node:fwadm nethvoice-proxy@any:routeadm"
+LABEL org.nethserver.authorizations="traefik@any:fulladm node:fwadm,portsadm nethvoice-proxy@any:routeadm"
 LABEL org.nethserver.tcp-ports-demand="31"
 LABEL org.nethserver.rootfull="0"
 ARG REPOBASE=ghcr.io/nethserver


### PR DESCRIPTION
fwadm allows to open ports on install, but not on update  🤷‍♂️
https://github.com/NethServer/dev/issues/7323