### PR TITLE
fix(events): validate ICEENFORCE in proxy settings

### DIFF
--- a/imageroot/events/nethvoice-proxy-settings-changed/00validate_event
+++ b/imageroot/events/nethvoice-proxy-settings-changed/00validate_event
@@ -29,6 +29,7 @@ ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip"
 # Check if there is something changed in the configuration
 if (os.getenv('NETHVOICE_PROXY_FQDN') == ksrv[0]["fqdn"] and
     os.getenv('PROXY_IP') == ksrv[0]["host"] and
-    os.getenv('PROXY_PORT') == ksrv[0]["port"]):
+    os.getenv('PROXY_PORT') == ksrv[0]["port"] and
+    os.getenv('ICEENFORCE') == ksrv[0]["address"]):
     print(agent.SD_DEBUG + "Event ignored: configuration not changed")
     sys.exit(4)


### PR DESCRIPTION
Ensure the `ICEENFORCE` environment variable is validated against the
`address` field in the service provider configuration. This fix prevents
false positives when determining if the proxy settings have changed.

https://github.com/NethServer/dev/issues/7345
