### PR TITLE
fix(provisiong): Trigger retrieve when phone TLS config changes

### DIFF
--- a/freepbx/var/www/html/freepbx/rest/modules/provisioning-v2.php
+++ b/freepbx/var/www/html/freepbx/rest/modules/provisioning-v2.php
@@ -103,6 +103,7 @@ $app->post('/extensions/{extension}/srtp/{enabled}', function (Request $request,
     $sql = 'UPDATE rest_devices_phones SET srtp = ? WHERE extension = ?';
     $stmt = $dbh->prepare($sql);
     $stmt->execute(array($media_encryption,$args['extension']));
+    system('/var/www/html/freepbx/rest/lib/retrieveHelper.sh > /dev/null &');
     return $response->withStatus(200);
 });
 


### PR DESCRIPTION
Phones are configured to use or not TLS  by a switch on interface. The API doesn't triggered FreePBX retrieve config (apply changes) therfore if the phone is rebooted after making the change without doing any other change on interface, the new TLS configuration isn't applied