### PR TITLE
refactor: restart all services on configure

### DIFF
--- a/imageroot/actions/configure-module/20setenvs
+++ b/imageroot/actions/configure-module/20setenvs
@@ -55,38 +55,3 @@ passwordsfile['NETHVOICE_USER_PORTAL_PASSWORD'] = request.get('nethvoice_adm_pas
 
 # write the passwords.env file
 agent.write_envfile("passwords.env", passwordsfile)
-
-#Check if the services must be restarted
-agent.set_env('RESTART_SERVICES', '')
-services_to_restart = set()
-if 'nethvoice_host' in request and os.getenv('NETHVOICE_HOST') != request['nethvoice_host']:
-    services_to_restart.add('freepbx.service')
-    services_to_restart.add('nethcti-ui.service')
-    services_to_restart.add('reports-api.service')
-    services_to_restart.add('reports-ui.service')
-    services_to_restart.add('tancredi.service')
-
-if 'reports_international_prefix' in request and os.getenv('REPORTS_INTERNATIONAL_PREFIX') != request['reports_international_prefix']:
-    services_to_restart.add('reports-api.service')
-    services_to_restart.add('reports-ui.service')
-
-if 'timezone' in request and os.getenv('TIMEZONE') != request['timezone']:
-    services_to_restart.add('freepbx.service')
-    services_to_restart.add('janus.service')
-    services_to_restart.add('mariadb.service')
-    services_to_restart.add('nethcti-ui.service')
-    services_to_restart.add('phonebook.service')
-    services_to_restart.add('reports-api.service')
-    services_to_restart.add('reports-redis.service')
-    services_to_restart.add('reports-ui.service')
-    services_to_restart.add('tancredi.service')
-    services_to_restart.add('nethcti-server.service')
-
-# read from passwords.env file
-nethvoice_user_portal_password = passwordsfile['NETHVOICE_USER_PORTAL_PASSWORD']
-
-if (('nethvoice_adm_username' in request and os.getenv('NETHVOICE_USER_PORTAL_USERNAME') != request['nethvoice_adm_username']) or
-    ('nethvoice_adm_password' in request and nethvoice_user_portal_password != request['nethvoice_adm_password'])):
-    services_to_restart.add('freepbx.service')
-
-agent.set_env('RESTART_SERVICES', ' '.join(services_to_restart))

--- a/imageroot/actions/configure-module/50users
+++ b/imageroot/actions/configure-module/50users
@@ -18,19 +18,6 @@ agent.set_env('USER_DOMAIN', domain)
 
 # read from  the passwords.env file
 passwordsfile = agent.read_envfile("passwords.env")
-# read from passwords.env file
-bind_password = passwordsfile.get('NETHVOICE_LDAP_PASS','')
-
-# Add freepbx.service to the list of services to restart if the user domain configuration has changed
-services_to_restart = set(os.getenv('SERVICES_TO_RESTART', '').split(' '))
-if domparams['host'] != os.getenv('NETHVOICE_LDAP_HOST', '') or \
-   domparams['port'] != os.getenv('NETHVOICE_LDAP_PORT', '') or \
-   domparams['bind_dn'] != os.getenv('NETHVOICE_LDAP_USER', '') or \
-   domparams['bind_password'] != bind_password or \
-   domparams['schema'] != os.getenv('NETHVOICE_LDAP_SCHEMA', '') or \
-   domparams['base_dn'] != os.getenv('NETHVOICE_LDAP_BASE', ''):
-    services_to_restart.add('freepbx.service')
-agent.set_env('RESTART_SERVICES', ' '.join(services_to_restart))
 
 agent.set_env('NETHVOICE_LDAP_HOST', domparams['host'])
 agent.set_env('NETHVOICE_LDAP_PORT', domparams['port'])

--- a/imageroot/actions/configure-module/60sip_proxy
+++ b/imageroot/actions/configure-module/60sip_proxy
@@ -19,27 +19,10 @@ if proxy_id is None:
 # Get proxy srv records
 ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip", "tcp", {"module_id": proxy_id.removeprefix("module/")})
 
-
-services_to_restart = set(os.environ['RESTART_SERVICES'].split())
-
-# Check if proxy srv records are present
-if os.getenv('NETHVOICE_PROXY_FQDN') != ksrv[0]["fqdn"]:
-    # Restart tancredi to apply new configuration
-    services_to_restart.add("tancredi.service")
-    agent.set_env("NETHVOICE_PROXY_FQDN", ksrv[0]["fqdn"])
-
-if os.getenv('PROXY_IP') != ksrv[0]["host"]:
-    # Restart services to apply new configuration
-    services_to_restart.add("freepbx.service")
-    agent.set_env("PROXY_IP", ksrv[0]["host"])
-
-if os.getenv('PROXY_PORT') != ksrv[0]["port"]:
-    # Restart services to apply new configuration
-    services_to_restart.add("freepbx.service")
-    agent.set_env("PROXY_PORT", ksrv[0]["port"])
-
-
-agent.set_env("RESTART_SERVICES", " ".join(services_to_restart))
+# Set environment variables for nethvoice-proxy
+agent.set_env("NETHVOICE_PROXY_FQDN", ksrv[0]["fqdn"])
+agent.set_env("PROXY_IP", ksrv[0]["host"])
+agent.set_env("PROXY_PORT", ksrv[0]["port"])
 
 # Configure nethvoice-proxy to route SIP traffic for Nethvoice
 response = agent.tasks.run(

--- a/imageroot/actions/configure-module/61ice_enforce
+++ b/imageroot/actions/configure-module/61ice_enforce
@@ -5,20 +5,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-import os
 import agent
 import agent.tasks
-
-services_to_restart = set(os.environ['RESTART_SERVICES'].split())
 
 # Get proxy srv records
 proxy_id = agent.resolve_agent_id('nethvoice-proxy@node')
 ksrv = agent.list_service_providers(agent.redis_connect(use_replica=True), "sip", "tcp", {"module_id": proxy_id.removeprefix("module/")})
 
 # Configure ICE to enforce the proxy ip address.
-# Restart services to apply new configuration if needed
-if os.environ["ICEENFORCE"] != ksrv[0]["address"]:
-    agent.set_env("ICEENFORCE", ksrv[0]["address"])
-    services_to_restart.add("janus.service")
-
-agent.set_env("RESTART_SERVICES", " ".join(services_to_restart))
+agent.set_env("ICEENFORCE", ksrv[0]["address"])

--- a/imageroot/actions/configure-module/80start_services
+++ b/imageroot/actions/configure-module/80start_services
@@ -9,10 +9,16 @@ set -e    # exit immediately if an error occurs
 exec 1>&2 # ensure any output is sent to stderr
 
 #restart services if they are already running
+RESTART_SERVICES="mariadb.service \
+                 freepbx.service \
+                 janus.service \
+                 nethcti-ui.service \
+                 tancredi.service \
+                 phonebook.service \
+                 reports-api.service \
+                 reports-ui.service"
 
-if [ -n "$RESTART_SERVICES" ]; then
-    systemctl --user try-restart $RESTART_SERVICES
-fi
+systemctl --user try-restart $RESTART_SERVICES
 
 # If the control reaches this step, the service can be enabled and started
 

--- a/imageroot/actions/configure-module/95service_adjust
+++ b/imageroot/actions/configure-module/95service_adjust
@@ -10,9 +10,5 @@ MARIADB_ROOT_PASSWORD=$(grep '^MARIADB_ROOT_PASSWORD=' ./passwords.env) && expor
 WIZARD_STEP=$(/usr/bin/podman exec mariadb mysql -u root -h 127.0.0.1 -P $NETHVOICE_MARIADB_PORT -p$MARIADB_ROOT_PASSWORD asterisk -BNe "select step from rest_wizard" | tr -d -c '[:digit:]')
 if [[ $WIZARD_STEP -ge 10 ]]; then
     echo "Starting nethcti-server" >> /dev/stderr
-    /usr/bin/systemctl --user start nethcti-server
+    /usr/bin/systemctl --user restart nethcti-server
 fi
-
-# restart asterisk when convenient
-echo "Restarting asterisk when convenient" >> /dev/stderr
-/usr/bin/podman exec -d freepbx asterisk -rx "core restart when convenient"


### PR DESCRIPTION
Instead of dynamically composing the `RESTART_SERVICES` list, use a
fixed list in `80start_services`. Adjust nethcti-server handling
in `95service_adjust` to use a restart command rather than start.
Remove redundant asterisk restart logic to avoid potential conflicts
and ensure cleaner execution flow in the configuration module.
This simplifies the configuration and ensures services are reliably
restarted after changes.

https://github.com/NethServer/dev/issues/7258
