### PR TITLE
feat: add pbookreader role, export phoenbook credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,24 @@ The file must be created inside the container. Example:
 touch /notify/restart_nethcti-server
 ```
 
+## Phonebook integration
+
+The module defines the `pbookreader` role that allows to call the following API:
+
+- `get-phonebook-credentials`: return the phonebook credentials, including the host, port, username and password
+
+This role can be used by other modules to access the phonebook.
+
+The module is a provider for the `<module_id>/srv/tcp/phonebook` service.
+It raises an event named `phonebook-settings-changed` with the following payload:
+
+- `module_id`: the module id
+- `node_id`: the node id
+- `module_uuid`: the module uuid
+- `reason`: the reason for the change
+
+Consumers of the events must then run the `get-phonebook-credentials` action on `module_id` to get the updated phonebook credentials.
+
 ## Uninstall
 
 To uninstall the instance:

--- a/imageroot/actions/configure-module/96publish_srv_keys
+++ b/imageroot/actions/configure-module/96publish_srv_keys
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import agent
+import os
+
+node_id = int(os.environ['NODE_ID'])
+agent_id = os.environ['AGENT_ID']
+module_uuid = os.environ['MODULE_UUID']
+
+with agent.redis_connect() as rdb:
+    node_address = rdb.hget(f'node/{node_id}/vpn', 'ip_address')
+
+# Create srv records in Redis for service discovery
+with agent.redis_connect(privileged=True) as prdb:
+    trx = prdb.pipeline()
+
+    service_key = agent_id + "/srv/tcp/phonebook"
+    trx.delete(service_key).hset(service_key, mapping={
+        "node_address": node_address,
+        "node_id": str(node_id),
+    })
+
+    # Publish change event
+    trx.publish(agent_id + "/event/phonebook-settings-changed", json.dumps({
+        "reason": os.getenv("AGENT_TASK_ACTION", "unknown"),
+        "module_id": os.environ['MODULE_ID'],
+        "node_id": node_id,
+        "module_uuid": module_uuid
+    }))
+
+    trx.execute()
+

--- a/imageroot/actions/create-module/30grants
+++ b/imageroot/actions/create-module/30grants
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e    # exit immediately if an error occurs
+exec 1>&2 # ensure any output is sent to stderr
+
+#
+# Allow other modules with role pbookreader to read phonebook credentials
+#
+redis-exec SADD "${AGENT_ID}/roles/pbookreader" "get-phonebook-credentials"

--- a/imageroot/actions/get-phonebook-credentials/20grant
+++ b/imageroot/actions/get-phonebook-credentials/20grant
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# This script is used to grant access to the phonebook database to other modules
+
+import agent
+import subprocess
+
+MARIADB_ROOT_PASSWORD = agent.read_envfile("passwords.env")["MARIADB_ROOT_PASSWORD"]
+SQL_QUERY = f"RENAME USER 'pbookuser'@'127.0.0.1' TO 'pbookuser';"
+
+# Do not check the return code, the query may fail if the user has already been renamed
+subprocess.run(['podman', 'exec', 'mariadb', 'mysql', 'asterisk', '-u', 'root', f'-p{MARIADB_ROOT_PASSWORD}', '-e', SQL_QUERY], capture_output=True)
+

--- a/imageroot/actions/get-phonebook-credentials/40read
+++ b/imageroot/actions/get-phonebook-credentials/40read
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import os
+import sys
+import json
+import agent
+
+with agent.redis_connect() as rdb:
+    node_address = rdb.hget(f'node/{int(os.environ["NODE_ID"])}/vpn', 'ip_address')
+    instance_name = rdb.get(f"module/{os.environ['MODULE_ID']}/ui_name")
+
+credentials = {
+    'host': node_address if node_address else '127.0.0.1',
+    'port': int(os.getenv('PHONEBOOK_DB_PORT', '3306')),
+    'database': os.getenv('PHONEBOOK_DB_NAME', 'phonebook'),
+    'user': os.getenv('PHONEBOOK_DB_USER', 'phonebook'),
+    'password': agent.read_envfile("passwords.env").get('PHONEBOOK_DB_PASS',""),
+    "instance_name": instance_name if instance_name else "",
+    "nethvoice_host": os.environ.get('NETHVOICE_HOST', '')
+    }
+
+json.dump(credentials, fp=sys.stdout)

--- a/imageroot/actions/get-phonebook-credentials/validate-output.json
+++ b/imageroot/actions/get-phonebook-credentials/validate-output.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Get phonebook credentials",
+    "$id": "http://nethserver.org/json-schema/task/output/nethvoice/get-phoenbook-credentials",
+    "description": "Get phoenbook credentials",
+    "examples": [
+        { 
+            "host": "10.5.4.1",
+            "port": 3306,
+            "database": "phonebook",
+            "user": "phonebook",
+            "password": "password",
+            "instance_name": "my voice",
+            "nethvoice_host": "voice.nethserver.org"
+        }
+    ],
+    "type": "object",
+    "required": [
+        "host",
+        "port",
+        "database",
+        "user",
+        "password",
+        "instance_name",
+        "nethvoice_host"
+    ],
+    "properties": {
+        "host": {
+            "description": "Host where the phonebook database is stored",
+            "type": "string"
+        },
+        "port": {
+            "description": "Port where the phonebook database is stored",
+            "type": "integer"
+        },
+        "database": {
+            "description": "Name of the phonebook database",
+            "type": "string"
+        },
+        "user": {
+            "description": "User to access the phonebook database",
+            "type": "string"
+        },
+        "password": {
+            "description": "Password to access the phonebook database",
+            "type": "string"
+        },
+        "instance_name": {
+            "description": "Name of the Nethvoice instance",
+            "type": "string"
+        },
+        "nethvoice_host": {
+            "description": "Host where the Nethvoice instance is exposed to",
+            "type": "string"
+        }
+    }
+}

--- a/imageroot/update-module.d/30grants
+++ b/imageroot/update-module.d/30grants
@@ -1,0 +1,1 @@
+../actions/create-module/30grants

--- a/tests/10_nethvoice_actions/10_get_phonebook_credentials.robot
+++ b/tests/10_nethvoice_actions/10_get_phonebook_credentials.robot
@@ -1,0 +1,9 @@
+*** Settings ***
+Library   SSHLibrary
+Resource  ../api.resource
+
+*** Test Cases ***
+Check get-phonebook-credentials action output
+    ${response} =  Run task    module/${module_id}/get-phonebook-credentials    {}
+    Should Be Equal As Strings    ${response['database']}    phonebook
+    Should Be Equal As Strings    ${response['user']}    pbookuser


### PR DESCRIPTION
This PR allow access to the phonebook from other modules like WebTop.
See Copilot review for more info.

NethServer/dev#7261

Update an existing instance:
```
api-cli run update-module --data '{"module_url": "ghcr.io/nethesis/nethvoice:issue7261", "instances": ["nethvoice1"]}'
```

