### PR TITLE
fix: add permission to view all groups & operators

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -87,7 +87,7 @@ images+=("${repobase}/${reponame}")
 ##      NethCTI Client     ##
 #############################
 reponame="nethvoice-cti-ui"
-container=$(buildah from ghcr.io/nethesis/nethvoice-cti:v0.6.1)
+container=$(buildah from ghcr.io/nethesis/nethvoice-cti:v0.7.1)
 
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/freepbx/initdb.d/migration.php
+++ b/freepbx/initdb.d/migration.php
@@ -357,3 +357,21 @@ foreach ($trunk_ids as $trunk_id) {
 	$stmt = $db->prepare($sql);
 	$stmt->execute([$trunk_id]);
 }
+
+# Check if all_groups permission exists
+$sql = "SELECT * FROM `rest_cti_permissions` WHERE `id` = 3500";
+$stmt = $db->prepare($sql);
+$stmt->execute();
+$res = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+if (count($res) == 0) {
+	# Add all_groups permission
+	$db->query("INSERT INTO `rest_cti_permissions` VALUES (3500,'all_groups','All groups','Allow to see all groups and operators')");
+	# Place all_groups permission inside presence panel
+	$db->query("INSERT INTO `rest_cti_macro_permissions_permissions` (`macro_permission_id`,`permission_id`) VALUES (5,3500)");
+	# Add all_groups permission to all profiles for retrocompatibility: before the creation of the permission any user could see all groups
+	$db->query("INSERT INTO `rest_cti_profiles_permissions` (`profile_id`,`permission_id`) VALUES
+		(1,3500),
+		(2,3500),
+		(3,3500);
+	");
+}

--- a/freepbx/wizard-ui/app/scripts/i18n/locale-en.json
+++ b/freepbx/wizard-ui/app/scripts/i18n/locale-en.json
@@ -171,5 +171,7 @@
   "extension left": "extension left",
   "privacy message notification": "The recording, possession, reproduction, communication or dissemination of telephone conversations outside of the cases permitted by law represents an offense. It is advisable to check that all the protections provided for by the Workers' Statute and the Privacy Code and the relevant applicable regulations have been adopted before activating this functionality.",
   "Warning": "Warning",
-  "Syncing message": "Users are syncing. Wait for the process to complete."
+  "Syncing message": "Users are syncing. Wait for the process to complete.",
+  "All groups": "All groups",
+  "Allow to see all groups and operators": "Allow to see all groups and operators"
 }

--- a/freepbx/wizard-ui/app/scripts/i18n/locale-it.json
+++ b/freepbx/wizard-ui/app/scripts/i18n/locale-it.json
@@ -1083,5 +1083,7 @@
   "extensions left": "interni rimanenti",
   "extension left": "interno rimanente",
   "privacy message notification": "La registrazione, detenzione, riproduzione, comunicazione o diffusione di conversazioni telefoniche fuori dai casi consentiti dalla legge rappresenta un illecito. E' opportuno verificare che siano state adottate   tutte le tutele previste dallo Statuto dei lavoratori e dal Codice privacy e dalle relative norme applicabili prima di attivare questa funzionalità.",
-  "Syncing message": "Gli utenti si stanno sincronizzando. Attendi che il processo sia terminato."
+  "Syncing message": "Gli utenti si stanno sincronizzando. Attendi che il processo sia terminato.",
+  "All groups": "Tutti i gruppi",
+  "Allow to see all groups and operators": "Consente di vedere tutti i gruppi e gli operatori"
 }

--- a/mariadb/docker-entrypoint-initdb.d/50_asterisk.rest_cti_macro_permissions_permissions.sql
+++ b/mariadb/docker-entrypoint-initdb.d/50_asterisk.rest_cti_macro_permissions_permissions.sql
@@ -20,6 +20,7 @@ INSERT INTO `rest_cti_macro_permissions_permissions` (`macro_permission_id`,`per
 (5,21),
 (5,22),
 (5,26),
+(5,3500),
 (6,23),
 (6,24),
 (8,25),

--- a/mariadb/docker-entrypoint-initdb.d/50_asterisk.rest_cti_permissions.sql
+++ b/mariadb/docker-entrypoint-initdb.d/50_asterisk.rest_cti_permissions.sql
@@ -28,4 +28,5 @@ INSERT INTO `rest_cti_permissions` (`id`,`name`,`displayname`,`description`) VAL
 (1000,"screen_sharing","Screen Sharing","Allow to share the desktop"),
 (2000,"phone_buttons","Phone buttons","Allow the user to customize functions of physical phone buttons. These values correspond to the Line Keys settings shown in Devices -> Models and Configurations pages"),
 (3000,"video_conference","Video Conference","Allow to start a video conference"),
+(3500,"all_groups","All groups","Allow to see all groups and operators"),
 (4000,"group_cdr","Group CDR","Allow to see call history of members of user groups");


### PR DESCRIPTION
Create a new `all_groups` permission that allows to see all groups and operators.

- `all_groups` permission is granted to Base, Standard and Advanced profiles on existing installations for retrocompatibility: before the creation of the permission any user could see all groups
- `all_groups` permission is NOT granted to any profile on fresh installations of NethVoice

Ref:
- https://github.com/NethServer/dev/issues/7277