### PR TITLE
fix: show group permissions only if all_groups perm is off

### DIFF
--- a/freepbx/wizard-ui/app/scripts/controllers/configurations/profiles.js
+++ b/freepbx/wizard-ui/app/scripts/controllers/configurations/profiles.js
@@ -27,6 +27,16 @@ angular.module('nethvoiceWizardUiApp')
       return $scope.tempBlacklist.includes(perm);
     }
 
+    $scope.shouldHideGroupPermission = function(obj_permissions, permName) {
+      // don't hide if it's not a group permission
+      if (!$scope.isGroupPermission(permName)) {
+        return false;
+      }
+      // hide group permission if all_groups permission is active
+      const allGroupsPerm = obj_permissions.permissions.find(p => p.name === 'all_groups');
+      return allGroupsPerm && allGroupsPerm.value;
+    }
+
     $scope.isGroupPermission = function(p) {
       return p.indexOf("grp_") !== -1;
     };

--- a/freepbx/wizard-ui/app/views/configurations/profiles.html
+++ b/freepbx/wizard-ui/app/views/configurations/profiles.html
@@ -230,7 +230,7 @@
                   </div>
                   <div class="row {{obj_permissions.permissions.length > 0 ? 'profile-permission-container-child' : ''}}" ng-if="obj_permissions.value">
                     <div
-                      ng-hide="(permission.name == 'phone_buttons' && wizard.provisioning != 'tancredi') || isInBlacklist(permission.name)"
+                      ng-hide="(permission.name == 'phone_buttons' && wizard.provisioning != 'tancredi') || isInBlacklist(permission.name) || shouldHideGroupPermission(obj_permissions, permission.name)"
                       class="col-lg-12 col-md-12 col-sm-12 col-xs-12 profile-permission child-permission"
                       ng-repeat="permission in obj_permissions.permissions"
                     >


### PR DESCRIPTION
Profiles page: hide **Group X** permissions if **All groups** permission is enabled

Ref:
- https://github.com/NethServer/dev/issues/7277