### PR TITLE
fix(profiles): hide switchboard operator permissions

### DIFF
--- a/freepbx/wizard-ui/app/scripts/controllers/configurations/profiles.js
+++ b/freepbx/wizard-ui/app/scripts/controllers/configurations/profiles.js
@@ -123,7 +123,7 @@ angular.module('nethvoiceWizardUiApp')
         $scope.showLicenseError = true;
           $timeout(function() {
             profile.macro_permissions.qmanager.value = false;
-        }, 1000); 
+        }, 1000);
       }
       // show privacy warning message
       if ((permission !== undefined && permission.name === 'recording' && permission.value) || (permission !== undefined && permission.name === 'spy' && permission.value) || (permission !== undefined && permission.name === 'intrude' && permission.value) || (permission !== undefined && permission.name === 'ad_recording' && permission.value)) {
@@ -278,4 +278,3 @@ angular.module('nethvoiceWizardUiApp')
 
     $scope.getInformationLicense();
   });
-  

--- a/freepbx/wizard-ui/app/scripts/controllers/configurations/profiles.js
+++ b/freepbx/wizard-ui/app/scripts/controllers/configurations/profiles.js
@@ -24,7 +24,7 @@ angular.module('nethvoiceWizardUiApp')
     $scope.tempBlacklist = ["chat", "video_conference", "trunks"];
 
     $scope.isInBlacklist = function(perm) {
-      return $scope.tempBlacklist.includes(perm);
+      return $scope.tempBlacklist.includes(perm) || perm.startsWith('in_queue_');
     }
 
     $scope.shouldHideGroupPermission = function(obj_permissions, permName) {

--- a/freepbx/wizard-ui/app/views/configurations/profiles.html
+++ b/freepbx/wizard-ui/app/views/configurations/profiles.html
@@ -249,7 +249,7 @@
                           ng-if="!isGroupPermission(permission.name) && permission.description.indexOf('Manage Queue') === 0"
                           popover-placement="top"
                           popover-trigger="'mouseenter'"
-                          popover-animation="true"             
+                          popover-animation="true"
                           uib-popover="{{'Manage Queue' | translate}} {{permission.description.substring('Manage Queue'.length, permission.description.length)}}"
                           class="config-span"
                         >

--- a/freepbx/wizard-ui/app/views/configurations/profiles.html
+++ b/freepbx/wizard-ui/app/views/configurations/profiles.html
@@ -235,8 +235,8 @@
                       ng-repeat="permission in obj_permissions.permissions"
                     >
                       <span class="col-lg-3 col-md-4 col-sm-6 col-xs-6">
-                        <span 
-                          ng-if="!isGroupPermission(permission.name) && permission.description.indexOf('Manage Queue') !== 0 && permission.description.indexOf('Use this queue for Operator Panel incoming calls') !== 0"
+                        <span
+                          ng-if="!isGroupPermission(permission.name) && permission.description.indexOf('Manage Queue') !== 0"
                           popover-placement="top"
                           popover-trigger="'mouseenter'"
                           popover-animation="true"
@@ -254,16 +254,6 @@
                           class="config-span"
                         >
                           {{permission.displayname | translate}}
-                        </span>
-                        <span
-                          ng-if="!isGroupPermission(permission.name) && permission.description.indexOf('Use this queue for Operator Panel incoming calls') === 0" 
-                          popover-placement="top"
-                          popover-trigger="'mouseenter'"
-                          popover-animation="true"
-                          uib-popover="{{'Use this queue for Operator Panel incoming calls' | translate}}"
-                          class="config-span"
-                        >
-                          {{permission.displayname.substring('Queue '.length, permission.displayname.length)}}
                         </span>
                         <span
                           ng-if="isGroupPermission(permission.name)"


### PR DESCRIPTION
- Hide switchboard operator permissions from Profiles page, i.e. those with a name starting with `in_queue_` and having description "Use this queue for Operator Panel incoming calls"
- Remove trailing spaces from source

Ref:
- https://github.com/nethserver/dev/issues/7366