### PR TITLE
fix: require Core 3.6+

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,6 +24,7 @@ ENTRYPOINT [ "/" ]
 LABEL org.nethserver.authorizations="traefik@any:fulladm node:fwadm,portsadm nethvoice-proxy@any:routeadm"
 LABEL org.nethserver.tcp-ports-demand="31"
 LABEL org.nethserver.rootfull="0"
+LABEL org.nethserver.min-core="3.6.2-0"
 ARG REPOBASE=ghcr.io/nethserver
 ARG IMAGETAG=latest
 LABEL org.nethserver.images="${REPOBASE}/nethvoice-mariadb:${IMAGETAG} \


### PR DESCRIPTION
The certificate-changed event handler works only with Core 3.6+.


Refs NethServer/dev#7350
Refs https://github.com/NethServer/ns8-repomd/pull/45