### PR TITLE
feat(configure-module): publish SIP UDP srv key

### DIFF
--- a/imageroot/actions/configure-module/96publish_srv_keys
+++ b/imageroot/actions/configure-module/96publish_srv_keys
@@ -34,5 +34,20 @@ with agent.redis_connect(privileged=True) as prdb:
         "module_uuid": module_uuid
     }))
 
+    service_key = agent_id + "/srv/udp/sip"
+    trx.delete(service_key).hset(service_key, mapping={
+        "node_address": node_address,
+        "node_id": str(node_id),
+        "port": os.environ["ASTERISK_SIP_PORT"],
+    })
+
+    # Publish change event
+    trx.publish(agent_id + "/event/pbx-settings-changed", json.dumps({
+        "reason": os.getenv("AGENT_TASK_ACTION", "unknown"),
+        "module_id": os.environ['MODULE_ID'],
+        "node_id": node_id,
+        "module_uuid": module_uuid
+    }))
+
     trx.execute()
 


### PR DESCRIPTION
Add logic to store SIP UDP service key in Redis and publish a
pbx-settings-changed event after updating. This ensures that changes are
visible to other components and that SIP port information is tracked
consistently.

This also allows the discovery of the NethVoice modules in the cluster.

https://github.com/NethServer/dev/issues/7456
