### PR TITLE
fix(update): restart nethcti-server when there aren't active calls

### DIFF
--- a/imageroot/update-module.d/80restart
+++ b/imageroot/update-module.d/80restart
@@ -4,7 +4,7 @@
 systemctl --user daemon-reload
 
 # try to restart all services if they are running
-systemctl --user try-restart mariadb nethcti-server nethcti-ui phonebook reports-api reports-redis reports-ui tancredi
+systemctl --user try-restart mariadb nethcti-ui phonebook reports-api reports-redis reports-ui tancredi
 
 # launch background tasks that restart freepbx only if there aren't any calls in progress
 echo "Restarting FreePBX, Janus and NethCTI server when there are no active calls"


### PR DESCRIPTION
nethcti-server was correctly added to the service to restart when there aren't active calls, but wasn't removed from the services to restart immediately
https://github.com/NethServer/dev/issues/7442