### PR TITLE
fix(update): restart service when there are no calls

### DIFF
--- a/imageroot/bin/restart-services-when-convenient
+++ b/imageroot/bin/restart-services-when-convenient
@@ -8,7 +8,7 @@ TIMEOUT=86400 # 24h
 
 for SECONDS in $(seq 1 $TIMEOUT); do
     # Check if there are any calls in progress
-    CALLS=$(podman exec freepbx asterisk -rx "core show channels" 2>/dev/null | grep "active calls" | cut -d" " -f1) || {
+    CALLS=$(podman exec freepbx asterisk -rx "core show channels" 2>/dev/null | grep "active call" | cut -d" " -f1) || {
         # If the command fails, assume there are no calls
         CALLS=0
     }
@@ -19,8 +19,6 @@ for SECONDS in $(seq 1 $TIMEOUT); do
     sleep 1
 done
 
-# Restart FreePBX
-for service in "$@"; do
-    echo "Restarting $service service wich was postponed for $SECONDS seconds"
-    systemctl --user try-restart $service
-done
+# Restart services
+echo "Restarting services $@ wich was postponed for $SECONDS seconds"
+systemctl --user try-restart $@

--- a/imageroot/update-module.d/80restart
+++ b/imageroot/update-module.d/80restart
@@ -3,9 +3,6 @@
 # reload systemd changes
 systemctl --user daemon-reload
 
-# try to restart all services if they are running
-systemctl --user try-restart mariadb nethcti-ui phonebook reports-api reports-redis reports-ui tancredi
-
 # launch background tasks that restart freepbx only if there aren't any calls in progress
 echo "Restarting FreePBX, Janus and NethCTI server when there are no active calls"
-restart-services-when-convenient freepbx janus nethcti-server &
+restart-services-when-convenient mariadb freepbx janus nethcti-server nethcti-ui phonebook reports-api reports-redis reports-ui tancredi &


### PR DESCRIPTION
https://github.com/NethServer/dev/issues/7442

- restart all services when there are no calls instead of only a few
- restart all services together to avoid multiple restarts for services depending on others
- fix check of active calls if there is only one active call