### PR TITLE
enhancement(logs): nocolor asterisk logs to improve pattern matching

### DIFF
--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -44,6 +44,7 @@ execincludes=yes
 dontwarn=yes
 runuser=asterisk
 rungroup=asterisk
+nocolor=yes
 
 [files]
 astctlpermissions=775


### PR DESCRIPTION
discussion: https://mattermost.nethesis.it/nethesis/pl/fcctu79jfib1u8xutfguyqeqmc

we cannot make GROK pattern when the color are written to log, we got something like this 

`May 20 14:57:56 VoipNethvoice freepbx[4165]: [2025-05-20 14:57:56] #033[1;33mNOTICE#033[0m[158]: #033[1;37mchan_sip.c#033[0m:#033[1;37m29058#033[0m #033[1;37mhandle_request_register#033[0m: Registration from '"1001" <sip:1001@93.42.2.141>' failed for '213.35.120.102:5819' - Wrong password`

and we would expect 

`May 20 14:57:56 VoipNethvoice freepbx[4165]: [2025-05-20 14:57:56] NOTICE[158]: chan_sip.c:29058 handle_request_register: Registration from '"1001" <sip:1001@93.42.2.141>' failed for '213.35.120.102:5819' - Wrong password`

Refs: https://github.com/NethServer/dev/issues/7481