### PR TITLE
fix: correct case for lets_encrypt env check

### DIFF
--- a/imageroot/actions/configure-module/71reports_api
+++ b/imageroot/actions/configure-module/71reports_api
@@ -31,7 +31,7 @@ response = agent.tasks.run(
         'instance': os.environ['MODULE_ID'] + '-reports-api',
         'url': 'http://127.0.0.1:' + os.environ["REPORTS_API_PORT"],
         'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
-        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "true",
+        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "True",
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/pbx-report-api',
         'strip_prefix': True

--- a/imageroot/actions/configure-module/72reports_ui
+++ b/imageroot/actions/configure-module/72reports_ui
@@ -38,7 +38,7 @@ response = agent.tasks.run(
         'instance': os.environ['MODULE_ID'] + '-reports-ui',
         'url': 'http://127.0.0.1:' + os.environ["REPORTS_UI_PORT"],
         'http2https':  os.environ["TRAEFIK_HTTP2HTTPS"] == "true",
-        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "true",
+        'lets_encrypt': os.environ["TRAEFIK_LETS_ENCRYPT"] == "True",
         'host': os.environ["NETHVOICE_HOST"],
         'path': '/pbx-report'
     },

--- a/imageroot/actions/restore-module/70configure_module
+++ b/imageroot/actions/restore-module/70configure_module
@@ -19,7 +19,7 @@ old_envs = request['environment']
 response = agent.tasks.run(agent_id=os.environ['AGENT_ID'], action='configure-module', data={
     "nethvoice_host": old_envs["NETHVOICE_HOST"],
     "nethcti_ui_host": old_envs["NETHCTI_UI_HOST"],
-    "lets_encrypt": old_envs["TRAEFIK_LETS_ENCRYPT"] == 'true',
+    "lets_encrypt": old_envs["TRAEFIK_LETS_ENCRYPT"] == 'True',
     "reports_international_prefix": old_envs["REPORTS_INTERNATIONAL_PREFIX"],
     "timezone": old_envs["TIMEZONE"],
     "user_domain": old_envs["USER_DOMAIN"],


### PR DESCRIPTION
Fix TRAEFIK_LETS_ENCRYPT environment variable evaluation to account
for Python's capitalized string representation of booleans ('True'
instead of 'true') when converting boolean values to strings.
