### PR TITLE
NethVoice, Improve FreePBX Entrypoint Robustness: Handle Missing Files, Directories, and DB Credentials

### DIFF
--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -109,7 +109,13 @@ chown -R asterisk:asterisk /var/lib/nethvoice/phonebook/uploads
 
 # Don't continue with initialization if the database is not ready
 if [[ -z "${AMPDBUSER}" || -z "${AMPDBPASS}" ]]; then
-	exit 0
+
+	if [ "$@" == "/usr/bin/supervisord" ]; then
+		echo "AMPDBUSER and AMPDBPASS are not set, exiting."
+		exit 0
+	fi
+
+	exec "$@"
 fi
 
 # Customized wizard page

--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -95,10 +95,12 @@ Driver = MariaDB Unicode
 Description = ODBC on asteriskcdrdb
 EOF
 
-mkdir -p /var/spool/asterisk/outgoing /var/spool/asterisk/tmp /var/spool/asterisk/uploads 
+mkdir -p /var/spool/asterisk/outgoing /var/spool/asterisk/tmp /var/spool/asterisk/uploads /var/lib/nethserver/nethcti/templates/customer_card
 chown asterisk:asterisk /var/lib/asterisk/db /var/spool/asterisk/outgoing /var/spool/asterisk/tmp /var/spool/asterisk/uploads /var/lib/nethserver/nethcti/templates/customer_card
 
-# Make sure config dir is writable from nethcti and freepbx containers
+# Make sure /etc/nethcti exists and is writable and the config directory is
+# writable from nethcti and freepbx containers
+mkdir -p /etc/nethcti
 chown -R asterisk:asterisk /etc/nethcti
 
 # make sure CSV upload path exists if /var/lib/nethvoice isn't a volume or already initialized

--- a/freepbx/entrypoint.sh
+++ b/freepbx/entrypoint.sh
@@ -55,7 +55,7 @@ EOF
 
 # Remove cdr.conf if it's empty. CDR module will create it at install.
 if [ ! -s /etc/asterisk/cdr.conf ]; then
-	rm /etc/asterisk/cdr.conf
+	rm -f /etc/asterisk/cdr.conf
 fi
 
 # create modules.conf


### PR DESCRIPTION
This PR enhances the resilience of the FreePBX container startup process.

It ensures that required directories are always present, preventing failures
when volumes are not mounted. Additionally, if database credentials are not
set, the script will now execute the provided command instead of exiting.

Both changes also address an issue encountered during the backup restore
procedure, where volumes are not mounted or database credentials are not
provided.

Also, the entrypoint now quietly removes an empty `cdr.conf` file, avoiding error
message if the file is missing.


https://github.com/NethServer/dev/issues/7513
