### PR TITLE
feature(dialplan): Add isTrunk=1 on INVITES sent to phones without encryption

### DIFF
--- a/freepbx/var/www/html/freepbx/admin/modules/nethcti3/functions.inc.php
+++ b/freepbx/var/www/html/freepbx/admin/modules/nethcti3/functions.inc.php
@@ -144,8 +144,8 @@ function nethcti3_get_config_late($engine) {
     global $db;
     switch($engine) {
         case "asterisk":
-        /* Change CF for CTI voicemail status */
-        $ext->replace('macro-dial-one', 'cf', '2', new ext_execif('$["${DB(AMPUSER/${DB_RESULT}/cidnum)}" == "" && "${DB_RESULT:0:2}" != "vm"]', 'Set','__REALCALLERIDNUM=${DEXTEN}'));
+            /* Change CF for CTI voicemail status */
+            $ext->replace('macro-dial-one', 'cf', '2', new ext_execif('$["${DB(AMPUSER/${DB_RESULT}/cidnum)}" == "" && "${DB_RESULT:0:2}" != "vm"]', 'Set','__REALCALLERIDNUM=${DEXTEN}'));
 
             /* Use main extension on login/logout/pause*/
             if (!empty(\FreePBX::Queues()->listQueues())) {


### PR DESCRIPTION
With this pull request, proxy doesn't offer RTP encryption to extensions configured from wizard that has encryption switch turned off.
If such extensions are called, the isTrunk=1 header is added to the INVITE.
When INVITE has this header, Nethvoice proxy [doesn't offer encryption to the endpoint](https://github.com/nethesis/ns8-nethvoice-proxy/pull/11). Normally this isn't necessary because if the endpoint can't adopt encryption should renegotiate, but old endpoints suck
https://github.com/NethServer/dev/issues/7524