### PR TITLE
feat(nethcti-ui): add Podman healthcheck

### DIFF
--- a/imageroot/systemd/user/nethcti-ui.service
+++ b/imageroot/systemd/user/nethcti-ui.service
@@ -38,6 +38,8 @@ ExecStart=/usr/bin/podman run \
     --env=FAVICON_URL=${FAVICON_URL} \
     --env=LOGIN_BACKGROUND_URL=${LOGIN_BACKGROUND_URL} \
     --tz=${TIMEZONE} \
+    --health-cmd='curl --silent --fail http://localhost:${NETHCTI_UI_PORT}/health' \
+    --health-on-failure=kill \
     ${NETHVOICE_CTI_UI_IMAGE}
 
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/nethcti-ui.ctr-id


### PR DESCRIPTION
Add --health-cmd and --health-on-failure=kill options to the Podman run
command in the nethcti-ui systemd service. On healthcheck failure,
Podman kills the container, triggering a systemd service restart.

Default Podman healthcheck parameters:
- --health-start-period=0s
- --health-interval=30s
- --health-retries=3

With these defaults, the container is immediately marked as "starting"
at startup. The first healthcheck runs right away and may fail if the
application is not ready. The container remains in the "starting" state
until a healthcheck succeeds or the start period elapses (default 0s).
After three consecutive failed checks (one every 30 seconds), the
container is marked as "unhealthy". This means the application should be
ready within about 1 minute after startup to avoid being marked
unhealthy.

After startup, if the application fails healthchecks, Podman allows up
to three consecutive failures (over 1 minute) before marking the
container as "unhealthy". Then the container is killed and systemd
restarts the service.

Startup example timeline:
0s:   First healthcheck fails (status: starting, failures: 1)
30s:  Second healthcheck fails (status: unhealthy, failures: 2)
60s:  Third healthcheck fails (status: unhealthy, failures: 3)
60s:  The container is killed

After startup example timeline:
0s:   First healthcheck fails (status: healthy, failures: 1)
30s:  Second healthcheck fails (status: healthy, failures: 2)
60s:  Third healthcheck fails (status: unhealthy, failures: 3)
60s:  The container is killed

This ensures the service is restarted automatically if it remains
unhealthy for more than 1 minute.

https://github.com/NethServer/dev/issues/7517
