### PR TITLE
fix(INVITE): make sure migrated app doesn't receive the isTrunk=1

### DIFF
--- a/freepbx/var/www/html/freepbx/admin/modules/nethcti3/functions.inc.php
+++ b/freepbx/var/www/html/freepbx/admin/modules/nethcti3/functions.inc.php
@@ -198,7 +198,7 @@ function nethcti3_get_config_late($engine) {
             }
         /* Add isTrunk for non encrypted extensions */
         // extensions with encryption disabled on wizard
-        $sql = "SELECT extension FROM rest_devices_phones WHERE srtp = 0";
+        $sql = "SELECT extension FROM rest_devices_phones WHERE srtp = 0 AND type = 'physical'";
         $stmt = $db->prepare($sql);
         $stmt->execute();
         $res = $stmt->fetchAll(\PDO::FETCH_ASSOC);


### PR DESCRIPTION
Only add isTrunk=1 to physical devices to make sure migrated app doesn't receive the additional tag https://github.com/NethServer/dev/issues/7524