### PR TITLE
fix(reports-api): add --add-host for NETHVOICE_HOST

### DIFF
--- a/imageroot/systemd/user/reports-api.service
+++ b/imageroot/systemd/user/reports-api.service
@@ -18,6 +18,7 @@ ExecStart=/usr/bin/podman run \
         --replace \
         --volume=reports_config:/opt/nethvoice-report:z \
         --network=host \
+        --add-host=${NETHVOICE_HOST}:127.0.0.1 \
         --env-file=%S/state/passwords.env \
         --env REPORTS_INTERNATIONAL_PREFIX \
         --env NETHVOICE_HOST \


### PR DESCRIPTION
Include --add-host=${NETHVOICE_HOST}:127.0.0.1 in the Podman run command
for reports-api.service. This ensures correct hostname resolution in NAT
environments.

https://github.com/NethServer/dev/issues/7569
