### PR TITLE
fix(tancredi): handle legacy custom NPX5v2 scopes

### DIFF
--- a/tancredi/usr/share/tancredi/scripts/upgrade.d/015-custom.php
+++ b/tancredi/usr/share/tancredi/scripts/upgrade.d/015-custom.php
@@ -60,7 +60,10 @@ foreach ($storage->listScopes() as $scope_id) {
         $scope_updates[] = sprintf('%s set to %s', $template_key, $template_value);
     }
 
-    $scope->metadata['version'] = 15;
+    $current_version = $scope->metadata['version'] ?? null;
+    if ($current_version === null || $current_version < 15) {
+        $scope->metadata['version'] = 15;
+    }
     $scope->setVariables();
     $logger->info(sprintf(
         'Fix %s applied to scope %s: %s',

--- a/tancredi/usr/share/tancredi/scripts/upgrade.d/015-custom.php
+++ b/tancredi/usr/share/tancredi/scripts/upgrade.d/015-custom.php
@@ -21,13 +21,16 @@
  */
 
 //
-// Rewrite custom scopes still inheriting from the legacy NP-X5 v2 model.
+// Rewrite writable scopes still inheriting from the legacy NP-X5 v2 model.
 // Tancredi 1.7.3 merged nethesis-NPX5v2 into nethesis-NPX5, but writable
-// custom scopes can still keep the old parent reference.
+// phone and custom-model scopes can still keep the old parent reference.
+// Legacy custom models also need tmpl_firmware_v2 explicitly written.
 //
 
 $source_model_id = 'nethesis-NPX5v2';
 $target_model_id = 'nethesis-NPX5';
+$template_key = 'tmpl_firmware_v2';
+$template_value = 'nethesis-firmware-v2.tmpl';
 $storage = $container->get('storage');
 $logger = $container->get('logger');
 
@@ -37,22 +40,32 @@ foreach ($storage->listScopes() as $scope_id) {
     }
 
     $scope = new \Tancredi\Entity\Scope($scope_id, $storage, $logger);
-    if (($scope->metadata['inheritFrom'] ?? null) !== $source_model_id) {
+    $scope_type = $scope->metadata['scopeType'] ?? null;
+    $inherits_legacy_model = ($scope->metadata['inheritFrom'] ?? null) === $source_model_id;
+    $is_legacy_custom_model = $scope_type === 'model' && strpos($scope_id, $source_model_id . '-') === 0;
+    $needs_template_fix = $is_legacy_custom_model && !array_key_exists($template_key, $scope->data);
+
+    if (!$inherits_legacy_model && !$needs_template_fix) {
         continue;
     }
 
-    if (isset($scope->metadata['version']) && $scope->metadata['version'] >= 15) {
-        continue;
+    $scope_updates = [];
+    if ($inherits_legacy_model) {
+        $scope->metadata['inheritFrom'] = $target_model_id;
+        $scope_updates[] = sprintf('inheritFrom changed from %s to %s', $source_model_id, $target_model_id);
     }
 
-    $scope->metadata['inheritFrom'] = $target_model_id;
+    if ($needs_template_fix) {
+        $scope->data[$template_key] = $template_value;
+        $scope_updates[] = sprintf('%s set to %s', $template_key, $template_value);
+    }
+
     $scope->metadata['version'] = 15;
     $scope->setVariables();
     $logger->info(sprintf(
-        'Fix %s applied to scope %s: inheritFrom changed from %s to %s',
+        'Fix %s applied to scope %s: %s',
         basename(__FILE__),
         $scope_id,
-        $source_model_id,
-        $target_model_id
+        implode('; ', $scope_updates)
     ));
 }


### PR DESCRIPTION
Extend the custom upgrade so writable model scopes derived from nethesis-NPX5v2 also receive tmpl_firmware_v2 while their inheritFrom reference is migrated to nethesis-NPX5.

This keeps custom derived models aligned with the NPX5 scope unification introduced for the upstream Tancredi migration and covers phones that inherit from those custom models.

Refs: https://github.com/NethServer/dev/issues/7478
Refs: https://github.com/NethServer/dev/issues/7927