### PR TITLE
fix(freepbx): remove userbase debug

### DIFF
--- a/freepbx/configure_users.php
+++ b/freepbx/configure_users.php
@@ -161,7 +161,6 @@ if (empty($results)) {
 $sql = "DELETE FROM kvstore_FreePBX_modules_Userman WHERE `id` = ? ; INSERT INTO kvstore_FreePBX_modules_Userman (`key`, `val`, `type`, `id`) VALUES ('auth-settings',?,'json-arr',?)";
 $stmt = $db->prepare($sql);
 $stmt->execute([$id, json_encode($ldap_settings), $id]);
-echo $ldap_settings['name'] . " userbase configuration: " . json_encode($ldap_settings) . "\n";
 
 // Check if domain changed and clean extensions
 $stmt = $db->prepare('SELECT `value` FROM `freepbx_settings` WHERE `keyword` = "USER_DOMAIN"');


### PR DESCRIPTION
Prevent leaking of the userbase password inside the logs

Example of log that has been removed:
```
May 11 06:37:24 rl1 freepbx[489799]: NethServer8 userbase configuration: {"host":"127.0.0.1","port":"20003","basedn":"dc=leader,dc=default,dc=gs,dc=nethserver,dc=net","username":"cn=ldapservice,dc=leader,dc=default,dc=gs,dc=nethserver,dc=net","password":"TVJ+OHtxFavkZxijAbgIl-vwocr_v8X:","displayname":"displayName","userdn":"ou=People","connection":"","localgroups":"0","createextensions":"","externalidattr":"entryUUID","descriptionattr":"description","commonnameattr":"uid","userobjectclass":"posixAccount","userobjectfilter":"(&(objectclass=posixAccount)(!(uid=domguests))(!(uid=domcomputers))(!(uid=nsstest))(!(uid=locals))(!(uid=domadmins)))","usernameattr":"uid","userfirstnameattr":"givenName","userlastnameattr":"sn","userdisplaynameattr":"displayName","usertitleattr":"","usercompanyattr":"","usercellphoneattr":"","userworkphoneattr":"telephoneNumber","userhomephoneattr":"homephone","userfaxphoneattr":"facsimileTelephoneNumber","usermailattr":"mail","usergroupmemberattr":"memberOf","la":"","groupnameattr":"cn","groupdnaddition":"ou=Groups","groupobjectclass":"posixGroup","groupobjectfilter":"(objectclass=posixGroup)","groupmemberattr":"memberUid","sync":"0 * * * *","driver":"Openldap2","name":"NethServer8"}
```