### PR TITLE
fix(reports): derive AD domain from LDAP_BASE for ldap-authenticate

### DIFF
--- a/reports/api/ldap-authenticate.sh
+++ b/reports/api/ldap-authenticate.sh
@@ -23,7 +23,7 @@ if [ "$ldap_schema" = "rfc2307" ]; then
         -D "uid=$1,ou=People,$NETHVOICE_LDAP_BASE" \
         -w "$2" >  /dev/null
 elif [ "$ldap_schema" = "ad" ]; then
-    NETHVOICE_AD_DOMAIN=$(echo "$NETHVOICE_LDAP_USER" | sed 's/.*@\(.*\)/\1/')
+    NETHVOICE_AD_DOMAIN=$(echo "$NETHVOICE_LDAP_BASE" | sed -E 's/ *//g;s/OU=[^,]*,//Ig;s/CN=[^,]*,//Ig;s/DC=//Ig;s/,/./g')
     exec ldapsearch \
         -x \
         -s base \


### PR DESCRIPTION
## Problem

Login to NethVoice Reports (`pbx-report-api`) fails for valid AD users with:

```
PAM authentication failed for user <user>: exit status 49
```

and the API returns `401 incorrect Username or Password`.

The same user can log in successfully on NethVoice CTI with the same credentials.

## Root cause

`reports/api/ldap-authenticate.sh` derives the AD domain from `NETHVOICE_LDAP_USER`:

```sh
NETHVOICE_AD_DOMAIN=$(echo "$NETHVOICE_LDAP_USER" | sed 's/.*@\(.*\)/\1/')
```

When `NETHVOICE_LDAP_USER` is configured as a DN (e.g. `CN=admin,CN=Users,DC=example,DC=local`) instead of UPN (`admin@example.local`), the `sed` regex finds no `@` and returns the string unchanged. The resulting bind DN becomes `<user>@CN=admin,CN=Users,DC=example,DC=local`, which AD rejects with `LdapErr ... data 52e` → ldap code 49.

CTI is not affected because `nethcti-server/scripts/ldap-authenticate.sh` derives the domain from `NETHVOICE_LDAP_BASE` by parsing `DC=` components.

## Fix

Align reports' AD domain derivation with the nethcti-server logic (parse `DC=` components from `NETHVOICE_LDAP_BASE`).

## Repro / verification

On a leader with `NETHVOICE_LDAP_SCHEMA=ad` and `NETHVOICE_LDAP_USER` in DN form:

```bash
podman exec reports-api /usr/bin/ldap-authenticate <user> '<password>'
# before: ldap_bind: Invalid credentials (49) ... data 52e
# after:  exit=0
```

Hot-patched the script in a customer's container, confirmed login works end-to-end on `pbx-report-api`.

Reference:
- https://github.com/NethServer/dev/issues/8001