### PR TITLE
chore: bump nethcti-server and nethcti-middleware refs to fix branches

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -92,7 +92,7 @@ images+=("${repobase}/${reponame}")
 ##    NethCTI Middleware   ##
 #############################
 reponame="nethvoice-cti-middleware"
-container=$(buildah from ghcr.io/nethesis/nethcti-middleware:v0.5.1)
+container=$(buildah from ghcr.io/nethesis/nethcti-middleware:fix-login-client-timeout)
 
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/build-images.sh
+++ b/build-images.sh
@@ -92,7 +92,7 @@ images+=("${repobase}/${reponame}")
 ##    NethCTI Middleware   ##
 #############################
 reponame="nethvoice-cti-middleware"
-container=$(buildah from ghcr.io/nethesis/nethcti-middleware:fix-login-client-timeout)
+container=$(buildah from ghcr.io/nethesis/nethcti-middleware:v0.5.2)
 
 # Commit the image
 buildah commit "${container}" "${repobase}/${reponame}"

--- a/nethcti-server/Containerfile
+++ b/nethcti-server/Containerfile
@@ -2,7 +2,7 @@
 FROM docker.io/library/alpine:3.17.10 as repofetcher
 WORKDIR /app
 RUN apk add --no-cache git
-ARG NETHCTI_SERVER_COMMIT=fix-auth-rest-listener-recovery
+ARG NETHCTI_SERVER_COMMIT=ns8
 RUN git clone https://github.com/nethesis/nethcti-server.git . \
     && git checkout "${NETHCTI_SERVER_COMMIT}"
 

--- a/nethcti-server/Containerfile
+++ b/nethcti-server/Containerfile
@@ -2,7 +2,7 @@
 FROM docker.io/library/alpine:3.17.10 as repofetcher
 WORKDIR /app
 RUN apk add --no-cache git
-ARG NETHCTI_SERVER_COMMIT=ns8
+ARG NETHCTI_SERVER_COMMIT=fix-auth-rest-listener-recovery
 RUN git clone https://github.com/nethesis/nethcti-server.git . \
     && git checkout "${NETHCTI_SERVER_COMMIT}"
 


### PR DESCRIPTION
## Summary

Bumps the build references for two upstream components so the module can be built and tested with the fixes applied:

- `nethcti-server/Containerfile`: `NETHCTI_SERVER_COMMIT` is set to the branch of the upstream fix — [nethesis/nethcti-server#349](https://github.com/nethesis/nethcti-server/pull/349).
- `build-images.sh`: the `nethcti-middleware` base image is changed from the released tag to the image tag produced by the upstream fix branch (the middleware build workflow publishes one image per branch) — [nethesis/nethcti-middleware#52](https://github.com/nethesis/nethcti-middleware/pull/52).

This PR is intended for testing the combined fixes end-to-end. Once both upstream PRs are merged and a proper release is cut, the refs should be moved back to a stable branch / version tag.