### PR TITLE
Fix: handle phonebook sources as ordered list

### DIFF
--- a/freepbx/wizard-ui/app/scripts/controllers/apps/phonebook.js
+++ b/freepbx/wizard-ui/app/scripts/controllers/apps/phonebook.js
@@ -105,6 +105,8 @@ angular.module('nethvoiceWizardUiApp')
       mapping: {}
     };
 
+    $scope.allSources = {};
+    $scope.allSourcesList = [];
     $scope.colsSources = {};
     $scope.colsDestinations = {};
 
@@ -118,10 +120,19 @@ angular.module('nethvoiceWizardUiApp')
       return $scope.allDBTypes[pbo.dbtype] ? $scope.allDBTypes[pbo.dbtype] : defval;
     };
 
+    $scope.normalizeSources = function (sources) {
+      $scope.allSources = angular.isObject(sources) ? sources : {};
+      $scope.allSourcesList = Object.keys($scope.allSources).map(function (key) {
+        var source = $scope.allSources[key] || {};
+        source._sourceKey = key;
+        return source;
+      });
+    };
+
     // rest api functions
     $scope.getAllSources = function () {
       PhonebookService.readConfig().then(function (res) {
-        $scope.allSources = res.data;
+        $scope.normalizeSources(res.data);
         $scope.view.changeRoute = false;
       }, function (err) {
         console.log(err);

--- a/freepbx/wizard-ui/app/views/apps/phonebook.html
+++ b/freepbx/wizard-ui/app/views/apps/phonebook.html
@@ -11,7 +11,7 @@
   <div class="wizard-pf-contents adjust-size">
     <h1 class="control-label centered" for="textInput-markup">{{'Phonebook sources configuration' | translate}}</h1>
     <!-- WIZARD -->
-    <div ng-if="(allSources | isEmpty)" class="blank-slate-pf ">
+    <div ng-if="(allSourcesList | isEmpty)" class="blank-slate-pf ">
       <div class="blank-slate-pf-icon">
         <span class="fa fa-book"></span>
       </div>
@@ -24,7 +24,7 @@
     </div>
     <!-- END WIZARD -->
     <!-- SOURCES -->
-    <h3 ng-if="!(allSources | isEmpty)" class="costumer-cards-margin-top" ng-if="true">{{'Sources' | translate}}</h3>
+    <h3 ng-if="!(allSourcesList | isEmpty)" class="costumer-cards-margin-top" ng-if="true">{{'Sources' | translate}}</h3>
     <div ng-if="onSaveSuccessSource" class="alert alert-success alert-dismissable">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
         <span class="pficon pficon-close"></span>
@@ -39,8 +39,8 @@
       <span class="pficon pficon-error-circle-o"></span>
       <strong>{{'Source not saved' | translate}}.</strong> {{'Source saving error' | translate}}
     </div>
-    <div ng-if="!(allSources | isEmpty)" class="row row-cards-pf adjust-card">
-      <div ng-repeat="(kg, g) in allSources track by $index | orderBy:'dbname'" class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
+    <div ng-if="!(allSourcesList | isEmpty)" class="row row-cards-pf adjust-card">
+      <div ng-repeat="g in allSourcesList | orderBy:'dbname' track by g._sourceKey" class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
         <div id="accordion-markup-{{$index}}" class="card-pf">
           <div data-toggle="collapse" data-parent="#accordion-markup-{{$index}}"
           href="#collapse-{{$index}}">
@@ -98,25 +98,25 @@
         <div class="card-pf-footer phonebook-card-footer">
           <div class="row">
             <div class="col-xs-12 col-md-12 col-lg-6">
-              <button data-toggle="modal" data-target="#creationsourceModal" ng-click="modifySource(kg, g)" class="btn btn-primary phonebook-footer-card-buttons"
+              <button data-toggle="modal" data-target="#creationsourceModal" ng-click="modifySource(g._sourceKey, g)" class="btn btn-primary phonebook-footer-card-buttons"
                 type="button">{{'Modify' | translate}}</button>
-              <button ng-click="openDeleteModal(kg)" class="btn btn-danger phonebook-footer-card-buttons" type="button">{{'Delete' | translate}}</button>
+              <button ng-click="openDeleteModal(g._sourceKey)" class="btn btn-danger phonebook-footer-card-buttons" type="button">{{'Delete' | translate}}</button>
             </div>
             <div class="col-xs-12 col-md-12 col-lg-6">
-              <button ng-disabled="!g.enabled" ng-click="runSyncNow(kg)" class="btn btn-default right-only phonebook-footer-card-buttons" type="button">
+              <button ng-disabled="!g.enabled" ng-click="runSyncNow(g._sourceKey)" class="btn btn-default right-only phonebook-footer-card-buttons" type="button">
                 <i class="fa fa-refresh sync-phonebook-icon" aria-hidden="true"></i>
                 {{'Sync' | translate}}
               </button>
-              <div id="phonebookSyncSpinner" ng-if="allSources[kg].syncing" class="spinner spinner-sm right-only"></div>
-              <span ng-show="!allSources[kg].syncing && allSources[kg].startSync && allSources[kg].synced" class="pficon pficon-ok sync-source-res right-only"></span>
-              <span ng-show="!allSources[kg].syncing && allSources[kg].startSync && !allSources[kg].synced" class="pficon pficon-error-circle-o sync-source-res right-only"></span>
+              <div id="phonebookSyncSpinner" ng-if="g.syncing" class="spinner spinner-sm right-only"></div>
+              <span ng-show="!g.syncing && g.startSync && g.synced" class="pficon pficon-ok sync-source-res right-only"></span>
+              <span ng-show="!g.syncing && g.startSync && !g.synced" class="pficon pficon-error-circle-o sync-source-res right-only"></span>
             </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-  <button ng-if="!(allSources | isEmpty)" ng-click="newSourceEvent()" data-toggle="modal" data-target="#creationsourceModal"
+  <button ng-if="!(allSourcesList | isEmpty)" ng-click="newSourceEvent()" data-toggle="modal" data-target="#creationsourceModal"
     class="btn btn-primary btn-lg right-only ng-binding ng-scope">{{"Create new source" | translate}}
   </button>
   <!-- END SOURCES -->

--- a/freepbx/wizard-ui/app/views/apps/phonebook.html
+++ b/freepbx/wizard-ui/app/views/apps/phonebook.html
@@ -40,7 +40,7 @@
       <strong>{{'Source not saved' | translate}}.</strong> {{'Source saving error' | translate}}
     </div>
     <div ng-if="!(allSourcesList | isEmpty)" class="row row-cards-pf adjust-card">
-      <div ng-repeat="g in allSourcesList | orderBy:'dbname' track by g._sourceKey" class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
+      <div ng-repeat="g in allSourcesList | orderBy:'dbname' track by g._sourceKey" ng-init="kg = g._sourceKey" class="col-xs-12 col-sm-6 col-md-4 col-lg-4">
         <div id="accordion-markup-{{$index}}" class="card-pf">
           <div data-toggle="collapse" data-parent="#accordion-markup-{{$index}}"
           href="#collapse-{{$index}}">

--- a/freepbx/wizard-ui/app/views/apps/phonebook.html
+++ b/freepbx/wizard-ui/app/views/apps/phonebook.html
@@ -24,7 +24,7 @@
     </div>
     <!-- END WIZARD -->
     <!-- SOURCES -->
-    <h3 ng-if="!(allSourcesList | isEmpty)" class="costumer-cards-margin-top" ng-if="true">{{'Sources' | translate}}</h3>
+    <h3 ng-if="!(allSourcesList | isEmpty)" class="costumer-cards-margin-top">{{'Sources' | translate}}</h3>
     <div ng-if="onSaveSuccessSource" class="alert alert-success alert-dismissable">
       <button type="button" class="close" data-dismiss="alert" aria-hidden="true">
         <span class="pficon pficon-close"></span>


### PR DESCRIPTION
## Problem

After uploading and saving a CSV phonebook source in the Wizard, the source could disappear from the "Phonebook sources" page even though the save request completed successfully.

In the browser console, AngularJS raised the following error:

`Error: [orderBy:notarray] Expected array but received: 0`

As a result, the page broke while rendering the saved sources list.

## Root cause

The phonebook configuration returned by the backend is an object map keyed by source id, not an array.

The AngularJS template was trying to render that structure with `orderBy:'dbname'`, but `orderBy` only works with arrays. Once the page refreshed after save, the template attempted to sort a non-array value and the sources section failed to render correctly.

At the same time, the existing controller logic still needed the original keyed object for operations such as modify, delete, and sync.

## Fix

The fix keeps the original keyed object for controller logic and introduces a derived `allSourcesList` array only for rendering.

In the controller, the response from `readConfig()` is normalized into:

- `allSources`: the original object map
- `allSourcesList`: an array built from the object entries, enriched with `_sourceKey`

In the template, all list rendering and `orderBy:'dbname'` operations now use `allSourcesList`, while actions such as modify, delete, and sync use `_sourceKey` to preserve the original source identity.

This removes the AngularJS rendering error and keeps the sources visible after save without changing the existing backend response format.