### PR TITLE
ci(workflows): add pr testing image workflow

### DIFF
--- a/.github/workflows/create-testing-pr-image.yml
+++ b/.github/workflows/create-testing-pr-image.yml
@@ -1,0 +1,59 @@
+name: NS8 PR Testing Image
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - 'tests/**'
+      - 'README.md'
+      - '.gitignore'
+      - 'LICENSE'
+      - 'renovate.json'
+      - 'test-module.sh'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  tagname:
+    name: Compute image tag
+    runs-on: ubuntu-latest
+    outputs:
+      imagetag: ${{ steps.imagetag.outputs.imagetag }}
+    steps:
+      - name: Compute image tag
+        id: imagetag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MERGE_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_NUMBER: ${{ github.run_number }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          short_sha="${MERGE_SHA::7}"
+          echo "imagetag=pr-${PR_NUMBER}.${RUN_NUMBER}-${RUN_ATTEMPT}.${short_sha}" >> "$GITHUB_OUTPUT"
+  create-testing-pr-image:
+    name: Create testing PR image
+    needs: tagname
+    uses: NethServer/ns8-github-actions/.github/workflows/publish-branch.yml@v1
+    with:
+      imagetag: ${{ needs.tagname.outputs.imagetag }}
+  comment-pr:
+    needs: [tagname, create-testing-pr-image]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment PR with image URL
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          IMAGETAG: ${{ needs.tagname.outputs.imagetag }}
+        run: |
+          reponame="${{ github.event.repository.name }}"
+          # Strip the ns8- prefix from the repo name
+          reponame="${reponame#ns8-}"
+          image_url="ghcr.io/${{ github.repository_owner }}/${reponame}:${IMAGETAG}"
+          gh pr comment -R ${{ github.repository }} "${PR_NUMBER}" --body "🔨 PR testing image: \`${image_url}\`"

--- a/.github/workflows/create-testing-pr-image.yml
+++ b/.github/workflows/create-testing-pr-image.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       imagetag: ${{ steps.imagetag.outputs.imagetag }}
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Compute image tag
         id: imagetag


### PR DESCRIPTION
## Summary

Add a GitHub Actions workflow triggered on pull requests (excluding docs, config, and test changes) that:
- Computes a testing image tag based on PR number, run number, and merge SHA
- Triggers the reusable `publish-branch` workflow from `NethServer/ns8-github-actions`
- Comments on the PR with the published `ghcr.io` image URL

## How to test

1. Fork the repo and push this PR branch as `main` 
1. Open a PR with non-documentation changes
1. Verify the workflow triggers the tagname, create-testing-pr-image, and comment-pr jobs
1. Confirm the PR receives a comment with the testing image URL

## Example
<img width="939" height="166" alt="Schermata del 2026-05-18 16-17-45" src="https://github.com/user-attachments/assets/5b27e817-6c06-4a44-87e2-d8671be5f7ae" />
