### PR TITLE
fix(cdr): exclude satellite internal channels from call history

### DIFF
--- a/nethcti-server/Containerfile
+++ b/nethcti-server/Containerfile
@@ -2,7 +2,7 @@
 FROM docker.io/library/alpine:3.17.10 as repofetcher
 WORKDIR /app
 RUN apk add --no-cache git
-ARG NETHCTI_SERVER_COMMIT=ns8
+ARG NETHCTI_SERVER_COMMIT=fix_call_report
 RUN git clone https://github.com/nethesis/nethcti-server.git . \
     && git checkout "${NETHCTI_SERVER_COMMIT}"
 


### PR DESCRIPTION
## Problem

When satellite call transcription is enabled, Asterisk logs internal technical channels (Snoop and ExternalMedia/UnicastRTP) created by satellite via ARI into the CDR table. These spurious records appear in the switchboard and user call history with:

- `dst = 's'`
- `src = ''`
- `lastapp = 'Stasis'`
- `lastdata = 'satellite'`

## Fix

Updates the `nethcti-server` reference to the `fix_call_report` branch, which adds `AND NOT (lastapp = "Stasis" AND lastdata = "satellite")` to all CDR history query WHERE clauses.

## Reference

- https://github.com/NethServer/dev/issues/8019