### PR TITLE
Use SATELLITE_HTTP_PORT for satellite RTP to fix port conflicts

### DIFF
--- a/imageroot/actions/create-module/05setenvs
+++ b/imageroot/actions/create-module/05setenvs
@@ -157,8 +157,8 @@ agent.set_env('SATELLITE_PGSQL_PORT', str(port_list[36]))
 # Asterisk WSS
 agent.set_env('ASTERISK_WSS_PORT', port_list[34])
 
-satellite_udp_port = allocate_rtp_ports_range(1)[0]
-agent.set_env('SATELLITE_RTP_PORT', satellite_udp_port)
+# Satellite RTP reuses SATELLITE_HTTP_PORT (same port number, UDP protocol).
+# No dedicated UDP port allocation needed.
 agent.set_env('SATELLITE_ARI_APP', 'satellite')
 agent.set_env('SATELLITE_ARI_USERNAME', 'satellite')
 agent.set_env('SATELLITE_MQTT_USERNAME', 'satellite')

--- a/imageroot/systemd/user/satellite.service
+++ b/imageroot/systemd/user/satellite.service
@@ -20,7 +20,7 @@ ExecStart=runagent /usr/bin/podman run \
     --env=ASTERISK_URL="http://127.0.1:${ASTERISK_WS_PORT}" \
     --env=ARI_APP=${SATELLITE_ARI_APP} \
     --env=ARI_USERNAME=${SATELLITE_ARI_USERNAME} \
-    --env=RTP_PORT=${SATELLITE_RTP_PORT} \
+    --env=RTP_PORT=${SATELLITE_HTTP_PORT} \
     --env=MQTT_URL="mqtt://127.0.0.1:${SATELLITE_MQTT_PORT}" \
     --env=MQTT_TOPIC_PREFIX=satellite \
     --env=MQTT_USERNAME=${SATELLITE_MQTT_USERNAME} \

--- a/imageroot/update-module.d/20allocate_ports
+++ b/imageroot/update-module.d/20allocate_ports
@@ -114,10 +114,12 @@ def allocate_rtp_ports_range(size):
     agent.assert_exp(int(seq) > 0)
     return (seq - size, seq - 1)
 
-if os.getenv('SATELLITE_RTP_PORT') is None:
-	satellite_rtp_port = allocate_rtp_ports_range(1)[0]
-	print(f"New port allocated for SATELLITE RTP: {satellite_rtp_port}", file=sys.stderr)
-	agent.set_env('SATELLITE_RTP_PORT', satellite_rtp_port)
+# SATELLITE_RTP_PORT is no longer needed: satellite reuses SATELLITE_HTTP_PORT
+# (same port number, UDP protocol). Unset any existing value so the env file
+# stays clean. The variable is kept in the environment for backward compat only.
+if os.getenv('SATELLITE_RTP_PORT') is not None:
+	agent.unset_env('SATELLITE_RTP_PORT')
+	print("SATELLITE_RTP_PORT removed: satellite now reuses SATELLITE_HTTP_PORT for RTP", file=sys.stderr)
 
 # add port for Asterisk WSS
 if not 'ASTERISK_WSS_PORT' in env:


### PR DESCRIPTION
## Problem

Satellite was using a dedicated UDP port (`SATELLITE_RTP_PORT`) allocated via the fake Redis-based system. On nodes with multiple NethVoice instances, this port could be already taken by another instance, causing satellite to fail on startup.

## Solution

Satellite listens for RTP from Asterisk on **localhost only**, so no public UDP port is actually needed. By reusing the same port number as `SATELLITE_HTTP_PORT` (TCP), both TCP and UDP share the same number — which is valid since they are separate protocol namespaces.

This avoids the fake Redis UDP allocation entirely.

## Changes

- `satellite.service`: pass `RTP_PORT=${SATELLITE_HTTP_PORT}` instead of `${SATELLITE_RTP_PORT}`
- `05setenvs`: remove `SATELLITE_RTP_PORT` allocation at install time
- `20allocate_ports`: unset `SATELLITE_RTP_PORT` on existing instances (migration cleanup)

## Related

Quick fix to unblock transcription/summary releases while PR #817 (full UDP port rework) is being reviewed and tested.