### PR TITLE
fix(reports): bump nethvoice-report and wire CDR cleanup task

### DIFF
--- a/imageroot/systemd/user/reports-scheduler.service
+++ b/imageroot/systemd/user/reports-scheduler.service
@@ -7,6 +7,7 @@ After=freepbx.service reports-api.service
 ExecStart=/usr/bin/podman exec freepbx /opt/nethvoice-report/scripts/queue-miner.php
 ExecStart=/usr/bin/podman exec reports-api tasks cdr
 ExecStart=/usr/bin/podman exec reports-api tasks cost
+ExecStart=/usr/bin/podman exec reports-api tasks cleanup
 ExecStart=/usr/bin/podman exec reports-api tasks views
 ExecStart=/usr/bin/podman exec reports-api tasks queries
 ExecStart=/usr/bin/podman exec reports-api tasks phonebook

--- a/reports/Containerfile
+++ b/reports/Containerfile
@@ -3,7 +3,7 @@
 FROM docker.io/library/alpine:3.17.10 as repofetcher
 WORKDIR /app
 RUN apk add --no-cache git
-ARG NETHVOICE_REPORT_COMMIT=af79d67ce65283315c070fc79d00db97a8399d8f
+ARG NETHVOICE_REPORT_COMMIT=a685996d3c32d5e23c750af44101203a8420a766
 RUN git clone https://github.com/nethesis/nethvoice-report \
     && cd nethvoice-report \
     && git checkout $NETHVOICE_REPORT_COMMIT

--- a/reports/Containerfile
+++ b/reports/Containerfile
@@ -3,7 +3,7 @@
 FROM docker.io/library/alpine:3.17.10 as repofetcher
 WORKDIR /app
 RUN apk add --no-cache git
-ARG NETHVOICE_REPORT_COMMIT=937040750d7df43a4719fe09a917e940b6cb15bf
+ARG NETHVOICE_REPORT_COMMIT=af79d67ce65283315c070fc79d00db97a8399d8f
 RUN git clone https://github.com/nethesis/nethvoice-report \
     && cd nethvoice-report \
     && git checkout $NETHVOICE_REPORT_COMMIT


### PR DESCRIPTION
## Summary

- Bump `NETHVOICE_REPORT_COMMIT` in `reports/Containerfile` to nethesis/nethvoice-report@a685996 (PR nethesis/nethvoice-report#211) — fixes the cross-period contamination of CDR partition tables, ships the new `tasks cleanup` command, and drains multi-statement result sets in `tasks views` so the scheduler no longer fails with "invalid connection".
- Wire `tasks cleanup` into `imageroot/systemd/user/reports-scheduler.service` between `cost` and `views`, so the retroactive sanitization of any rows already leaked into wrong partition tables runs during the existing nightly window (not at package upgrade) and is safe to re-run.

Refs NethServer/dev#8023