### PR TITLE
fix: stop ignoring Containerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ AGENTS.md
 NS8-MODULE.md
 .github/agents/
 COMPONENTS.md
-Containerfile
 deploys.sh
 DEVELOPMENT.md
 __pycache__/


### PR DESCRIPTION
Track the Containerfile in the repository so changes to the image
definition are visible and can be committed normally.
