### PR TITLE
chore(build): pin nethcti-server to issue_8038 for QA

### DIFF
--- a/nethcti-server/Containerfile
+++ b/nethcti-server/Containerfile
@@ -2,7 +2,7 @@
 FROM docker.io/library/alpine:3.17.10 as repofetcher
 WORKDIR /app
 RUN apk add --no-cache git
-ARG NETHCTI_SERVER_COMMIT=ns8
+ARG NETHCTI_SERVER_COMMIT=issue_8038
 RUN git clone https://github.com/nethesis/nethcti-server.git . \
     && git checkout "${NETHCTI_SERVER_COMMIT}"
 


### PR DESCRIPTION
## Summary

- Pin `NETHCTI_SERVER_COMMIT` in `nethcti-server/Containerfile` from `ns8` to `issue_8038` to build the image from the feature branch for QA testing.

> **Temporary**: revert to `ns8` tag before merge.

Refs: NethServer/dev#8038