### PR TITLE
chore(build): pin middleware to issue_8039 for QA

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -193,7 +193,7 @@ fi
 reponame="nethvoice-cti-middleware"
 if should_build "${reponame}"; then
     start_timing "${reponame}"
-    container=$(buildah from ghcr.io/nethesis/nethcti-middleware:v0.5.3)
+    container=$(buildah from ghcr.io/nethesis/nethcti-middleware:issue_8039)
 
     # Commit the image
     buildah commit "${container}" "${repobase}/${reponame}"


### PR DESCRIPTION
## Summary

- Pin `nethcti-middleware` image tag in `build-images.sh` from `v0.5.3` to `issue_8039` to pull the feature branch image for QA testing.

> **Temporary**: revert to a released v0.5.x tag before merge.

Refs: NethServer/dev#8039