### PR TITLE
feat(satellite): Check stt permission

### DIFF
--- a/freepbx/var/www/html/freepbx/admin/modules/satellite/bin/satellite_transcript
+++ b/freepbx/var/www/html/freepbx/admin/modules/satellite/bin/satellite_transcript
@@ -125,44 +125,84 @@ function main($argv) {
                     fail("No usable transcription segments found for uniqueid $uniqueid and linkedid $linkedid");
                 }
 
-                $apiUrl = get_satellite_api_url();
-                foreach ($segments as $index => $segment) {
-                    $segmentNumber = $index + 1;
-                    $segmentUniqueid = $uniqueid;
+                // Permission checks must use the normalized caller/callee
+                // extensions so Local legs and transfers resolve to the real
+                // party profile before we decide whether to upload.
+                $partyExtensions = collect_segment_party_extensions($segments);
+                $extensionsWithSatelliteStt = fetch_satellite_stt_extensions($partyExtensions);
+                $allowedPartyExtensions = filter_extensions_with_satellite_stt_permission($partyExtensions, $extensionsWithSatelliteStt);
+
+                if (empty($allowedPartyExtensions)) {
+                    log_message(
+                        "Skipping transcription for uniqueid $uniqueid and linkedid $linkedid because no call party has satellite_stt permission",
+                        __FILE__,
+                        __LINE__,
+                        __FUNCTION__
+                    );
                     debug_log(
-                        'Preparing segment audio',
+                        'Transcription skipped for missing satellite_stt permission',
                         __FILE__,
                         __LINE__,
                         __FUNCTION__,
                         array(
-                            'segment_uniqueid' => $segmentUniqueid,
-                            'segment' => format_segment_row($segment),
+                            'uniqueid' => $uniqueid,
+                            'linkedid' => $linkedid,
+                            'party_extensions' => $partyExtensions,
                         )
                     );
-                    $audioFile = create_segment_audio(
-                        $segment,
-                        $segmentNumber,
-                        $uniqueid,
-                        $linkedid,
-                        $recordingStart,
-                        $transmittedRecordingFile,
-                        $receivedRecordingFile,
-                        $tmpFiles
+                } else {
+                    debug_log(
+                        'Transcription allowed by satellite_stt permission',
+                        __FILE__,
+                        __LINE__,
+                        __FUNCTION__,
+                        array(
+                            'uniqueid' => $uniqueid,
+                            'linkedid' => $linkedid,
+                            'party_extensions' => $partyExtensions,
+                            'allowed_extensions' => $allowedPartyExtensions,
+                        )
                     );
 
-                    $segment['audio_data'] = $audioFile;
-                    debug_log(
-                        'Segment audio ready',
-                        __FILE__,
-                        __LINE__,
-                        __FUNCTION__,
-                        array(
-                            'segment_uniqueid' => $segmentUniqueid,
-                            'audio_file' => $audioFile,
-                            'size_bytes' => @filesize($audioFile),
-                        )
-                    );
-                    post_segment_to_satellite($apiUrl, $segmentUniqueid, $linkedid, $segment);
+                    $apiUrl = get_satellite_api_url();
+                    foreach ($segments as $index => $segment) {
+                        $segmentNumber = $index + 1;
+                        $segmentUniqueid = $uniqueid;
+                        debug_log(
+                            'Preparing segment audio',
+                            __FILE__,
+                            __LINE__,
+                            __FUNCTION__,
+                            array(
+                                'segment_uniqueid' => $segmentUniqueid,
+                                'segment' => format_segment_row($segment),
+                            )
+                        );
+                        $audioFile = create_segment_audio(
+                            $segment,
+                            $segmentNumber,
+                            $uniqueid,
+                            $linkedid,
+                            $recordingStart,
+                            $transmittedRecordingFile,
+                            $receivedRecordingFile,
+                            $tmpFiles
+                        );
+
+                        $segment['audio_data'] = $audioFile;
+                        debug_log(
+                            'Segment audio ready',
+                            __FILE__,
+                            __LINE__,
+                            __FUNCTION__,
+                            array(
+                                'segment_uniqueid' => $segmentUniqueid,
+                                'audio_file' => $audioFile,
+                                'size_bytes' => @filesize($audioFile),
+                            )
+                        );
+                        post_segment_to_satellite($apiUrl, $segmentUniqueid, $linkedid, $segment);
+                    }
                 }
             }
         }
@@ -1365,6 +1405,82 @@ function fetch_users_by_extension() {
         log_exception($e, __FILE__, __LINE__, __FUNCTION__, 'Unable to read FreePBX users table');
     }
     return $users;
+}
+
+function collect_segment_party_extensions($segments) {
+    $extensions = array();
+    $seenExtensions = array();
+
+    foreach ($segments as $segment) {
+        foreach (array('caller_num', 'callee_num') as $field) {
+            $extension = isset($segment[$field]) ? trim((string) $segment[$field]) : '';
+            if ($extension !== '' && !isset($seenExtensions[$extension])) {
+                $extensions[] = $extension;
+                $seenExtensions[$extension] = true;
+            }
+        }
+    }
+
+    return $extensions;
+}
+
+function fetch_satellite_stt_extensions($extensions) {
+    global $db;
+
+    $normalizedExtensions = array();
+    foreach ($extensions as $extension) {
+        $extension = trim((string) $extension);
+        if ($extension !== '') {
+            $normalizedExtensions[$extension] = true;
+        }
+    }
+    $extensions = array_keys($normalizedExtensions);
+
+    if (empty($extensions)) {
+        return array();
+    }
+
+    $allowedExtensions = array();
+    try {
+        $sql = "SELECT DISTINCT uu.default_extension
+            FROM userman_users uu
+            JOIN rest_users ru ON ru.user_id = uu.id
+            JOIN rest_cti_profiles_macro_permissions profile_macro ON profile_macro.profile_id = ru.profile_id
+            JOIN rest_cti_macro_permissions macro_permission ON macro_permission.id = profile_macro.macro_permission_id
+            JOIN rest_cti_profiles_permissions profile_permission ON profile_permission.profile_id = ru.profile_id
+            JOIN rest_cti_permissions permission ON permission.id = profile_permission.permission_id
+            WHERE macro_permission.name = ?
+              AND permission.name = ?
+              AND uu.default_extension IN (" . implode(', ', array_fill(0, count($extensions), '?')) . ")
+              AND uu.default_extension IS NOT NULL
+              AND uu.default_extension <> ''
+              AND uu.default_extension <> 'none'";
+        $stmt = $db->prepare($sql);
+        $stmt->execute(array_merge(array('nethvoice_cti', 'satellite_stt'), $extensions));
+
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $extension) {
+            $extension = trim((string) $extension);
+            if ($extension !== '') {
+                $allowedExtensions[$extension] = true;
+            }
+        }
+    } catch (Throwable $e) {
+        log_exception($e, __FILE__, __LINE__, __FUNCTION__, 'Unable to read satellite_stt CTI permissions');
+    }
+
+    return $allowedExtensions;
+}
+
+function filter_extensions_with_satellite_stt_permission($partyExtensions, $extensionsWithPermission) {
+    $allowedExtensions = array();
+
+    foreach ($partyExtensions as $extension) {
+        if (isset($extensionsWithPermission[$extension])) {
+            $allowedExtensions[] = $extension;
+        }
+    }
+
+    return $allowedExtensions;
 }
 
 /**

--- a/freepbx/var/www/html/freepbx/admin/modules/satellite/bin/satellite_transcript
+++ b/freepbx/var/www/html/freepbx/admin/modules/satellite/bin/satellite_transcript
@@ -127,12 +127,32 @@ function main($argv) {
 
                 // Permission checks must use the normalized caller/callee
                 // extensions so Local legs and transfers resolve to the real
-                // party profile before we decide whether to upload.
+                // party profile before we decide whether to upload each slice.
                 $partyExtensions = collect_segment_party_extensions($segments);
-                $extensionsWithSatelliteStt = fetch_satellite_stt_extensions($partyExtensions);
-                $allowedPartyExtensions = filter_extensions_with_satellite_stt_permission($partyExtensions, $extensionsWithSatelliteStt);
+                $registeredPartyExtensions = filter_registered_user_extensions($partyExtensions, $usersByExtension);
+                $extensionsWithSatelliteStt = fetch_satellite_stt_extensions($registeredPartyExtensions);
+                $allowedPartyExtensions = filter_extensions_with_satellite_stt_permission($registeredPartyExtensions, $extensionsWithSatelliteStt);
+                $segments = filter_segments_with_satellite_stt_permission($segments, $extensionsWithSatelliteStt);
 
-                if (empty($allowedPartyExtensions)) {
+                if (empty($registeredPartyExtensions)) {
+                    log_message(
+                        "Skipping transcription for uniqueid $uniqueid and linkedid $linkedid because no call party is a registered user extension",
+                        __FILE__,
+                        __LINE__,
+                        __FUNCTION__
+                    );
+                    debug_log(
+                        'Transcription skipped because no segment party maps to a registered user extension',
+                        __FILE__,
+                        __LINE__,
+                        __FUNCTION__,
+                        array(
+                            'uniqueid' => $uniqueid,
+                            'linkedid' => $linkedid,
+                            'party_extensions' => $partyExtensions,
+                        )
+                    );
+                } elseif (empty($allowedPartyExtensions)) {
                     log_message(
                         "Skipping transcription for uniqueid $uniqueid and linkedid $linkedid because no call party has satellite_stt permission",
                         __FILE__,
@@ -148,6 +168,7 @@ function main($argv) {
                             'uniqueid' => $uniqueid,
                             'linkedid' => $linkedid,
                             'party_extensions' => $partyExtensions,
+                            'registered_party_extensions' => $registeredPartyExtensions,
                         )
                     );
                 } else {
@@ -160,7 +181,9 @@ function main($argv) {
                             'uniqueid' => $uniqueid,
                             'linkedid' => $linkedid,
                             'party_extensions' => $partyExtensions,
+                            'registered_party_extensions' => $registeredPartyExtensions,
                             'allowed_extensions' => $allowedPartyExtensions,
+                            'upload_segment_count' => count($segments),
                         )
                     );
 
@@ -1402,7 +1425,7 @@ function fetch_users_by_extension() {
             }
         }
     } catch (Throwable $e) {
-        log_exception($e, __FILE__, __LINE__, __FUNCTION__, 'Unable to read FreePBX users table');
+        fail('Unable to read FreePBX users table: ' . $e->getMessage());
     }
     return $users;
 }
@@ -1424,17 +1447,15 @@ function collect_segment_party_extensions($segments) {
     return $extensions;
 }
 
+function filter_registered_user_extensions($partyExtensions, $usersByExtension) {
+    return array_values(array_filter($partyExtensions, function ($extension) use ($usersByExtension) {
+        return isset($usersByExtension[$extension]);
+    }));
+}
+
+// Callers pass unique, trimmed extension values from collect_segment_party_extensions().
 function fetch_satellite_stt_extensions($extensions) {
     global $db;
-
-    $normalizedExtensions = array();
-    foreach ($extensions as $extension) {
-        $extension = trim((string) $extension);
-        if ($extension !== '') {
-            $normalizedExtensions[$extension] = true;
-        }
-    }
-    $extensions = array_keys($normalizedExtensions);
 
     if (empty($extensions)) {
         return array();
@@ -1465,22 +1486,32 @@ function fetch_satellite_stt_extensions($extensions) {
             }
         }
     } catch (Throwable $e) {
-        log_exception($e, __FILE__, __LINE__, __FUNCTION__, 'Unable to read satellite_stt CTI permissions');
+        fail('Unable to read satellite_stt CTI permissions: ' . $e->getMessage());
     }
 
     return $allowedExtensions;
 }
 
 function filter_extensions_with_satellite_stt_permission($partyExtensions, $extensionsWithPermission) {
-    $allowedExtensions = array();
+    return array_values(array_filter($partyExtensions, function ($extension) use ($extensionsWithPermission) {
+        return isset($extensionsWithPermission[$extension]);
+    }));
+}
 
-    foreach ($partyExtensions as $extension) {
-        if (isset($extensionsWithPermission[$extension])) {
-            $allowedExtensions[] = $extension;
+function filter_segments_with_satellite_stt_permission($segments, $extensionsWithPermission) {
+    $allowedSegments = array();
+
+    foreach ($segments as $segment) {
+        foreach (array('caller_num', 'callee_num') as $field) {
+            $extension = isset($segment[$field]) ? trim((string) $segment[$field]) : '';
+            if ($extension !== '' && isset($extensionsWithPermission[$extension])) {
+                $allowedSegments[] = $segment;
+                continue 2;
+            }
         }
     }
 
-    return $allowedExtensions;
+    return $allowedSegments;
 }
 
 /**

--- a/freepbx/var/www/html/freepbx/admin/modules/satellite/tests/satellite_stt_permission_gate_test.php
+++ b/freepbx/var/www/html/freepbx/admin/modules/satellite/tests/satellite_stt_permission_gate_test.php
@@ -1,0 +1,121 @@
+#!/usr/bin/env php
+<?php
+
+require_once __DIR__ . '/bootstrap.php';
+
+satellite_test_bootstrap();
+
+$segments = array(
+    array(
+        'caller_num' => '3401234567',
+        'callee_num' => '201',
+    ),
+    array(
+        'caller_num' => '201',
+        'callee_num' => '202',
+    ),
+    array(
+        'caller_num' => '201',
+        'callee_num' => '',
+    ),
+);
+
+assert_same(
+    array('3401234567', '201', '202'),
+    collect_segment_party_extensions($segments),
+    'Segment permission gate must collect unique caller and callee numbers'
+);
+
+assert_same(
+    array('202'),
+    filter_extensions_with_satellite_stt_permission(
+        collect_segment_party_extensions($segments),
+        array('202' => true)
+    ),
+    'One permitted party must be enough to allow transcription'
+);
+
+assert_same(
+    array('201'),
+    filter_extensions_with_satellite_stt_permission(
+        collect_segment_party_extensions($segments),
+        array('201' => true)
+    ),
+    'Caller permission must allow transcription'
+);
+
+assert_same(
+    array(),
+    filter_extensions_with_satellite_stt_permission(
+        collect_segment_party_extensions($segments),
+        array('203' => true)
+    ),
+    'Transcription must be skipped when no call party has satellite_stt permission'
+);
+
+assert_same(
+    array(),
+    filter_extensions_with_satellite_stt_permission(array(), array('201' => true)),
+    'Empty party lists must not authorize transcription'
+);
+
+assert_same(
+    array('201', '202'),
+    filter_registered_user_extensions(
+        collect_segment_party_extensions($segments),
+        array('201' => 'Alice', '202' => 'Bob')
+    ),
+    'External numbers must not be reported as registered user extensions'
+);
+
+$transferSegments = array(
+    array(
+        'caller_num' => '201',
+        'callee_num' => '202',
+        'label' => 'before transfer',
+    ),
+    array(
+        'caller_num' => '202',
+        'callee_num' => '203',
+        'label' => 'after transfer',
+    ),
+);
+
+assert_same(
+    array($transferSegments[0]),
+    filter_segments_with_satellite_stt_permission($transferSegments, array('201' => true)),
+    'Permission from one segment party must not authorize later unrelated segments'
+);
+
+assert_same(
+    array($transferSegments[1]),
+    filter_segments_with_satellite_stt_permission($transferSegments, array('203' => true)),
+    'Each segment must be authorized by one of its active parties'
+);
+
+class SatelliteSttFailingDb {
+    public function prepare($sql) {
+        throw new RuntimeException('database unavailable');
+    }
+}
+
+global $db;
+$db = new SatelliteSttFailingDb();
+
+assert_throws(
+    function () {
+        fetch_satellite_stt_extensions(array('201'));
+    },
+    'Unable to read satellite_stt CTI permissions: database unavailable',
+    'Permission lookup failures must abort transcription instead of looking like a denied call'
+);
+
+assert_throws(
+    function () {
+        fetch_users_by_extension();
+    },
+    'Unable to read FreePBX users table: database unavailable',
+    'Registered-user lookup failures must abort transcription instead of looking like an external-only call'
+);
+
+fwrite(STDOUT, "ok - satellite STT permission gate regression\n");


### PR DESCRIPTION
Check transcription eligibility into satellite_transcript after caller and callee segments are normalized. Resolve the party extensions against profiles with both nethvoice_cti and satellite_stt enabled, and exit before audio trimming or upload when no parties are eligible.

This keeps the dialplan launch unchanged while preventing unauthorized calls from proceeding to transcription upload.